### PR TITLE
Refactor World test resource management to use scala.util.Using

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -21,7 +21,6 @@ lazy val settings = Seq(
   libraryDependencies += "org.scala-lang.modules" %% "scala-java8-compat" % "1.0.2",
   libraryDependencies += "org.typelevel" %% "cats-core"      % "2.13.0",
   libraryDependencies += "org.typelevel" %% "alleycats-core" % "2.13.0",
-  libraryDependencies += "org.typelevel" %% "cats-effect"    % "3.7.0",
   libraryDependencies += "net.bytebuddy"  % "byte-buddy"     % "1.18.7",
   libraryDependencies += "org.scala-lang.modules" %% "scala-collection-contrib" % "0.4.0",
   libraryDependencies += "org.scala-lang" % "scala-reflect" % "2.13.18",

--- a/src/benchmark/scala/com/sageserpent/plutonium/Benchmark.scala
+++ b/src/benchmark/scala/com/sageserpent/plutonium/Benchmark.scala
@@ -1,12 +1,10 @@
 package com.sageserpent.plutonium
 
-import cats.effect.IO
-import cats.effect.unsafe.implicits.global
 import com.sageserpent.americium.utilities.randomEnrichment._
 
 import java.time.Instant
 import scala.concurrent.duration._
-import scala.util.Random
+import scala.util.{Random, Using}
 
 trait Benchmark extends WorldEfficientInMemoryImplementationResource {
   implicit class Enhancement(randomBehaviour: Random) {
@@ -23,93 +21,88 @@ trait Benchmark extends WorldEfficientInMemoryImplementationResource {
 
     val startTime = Deadline.now
 
-    val world: IO[World] =
-      worldResource.use(world =>
-        IO {
-          for (step <- 0 until size) {
-            val eventId = step - randomBehaviour
-              .chooseAnyNumberFromZeroToOneLessThan(20)
+    Using.resource(makeWorld()) { world =>
+      for (step <- 0 until size) {
+        val eventId = step - randomBehaviour
+          .chooseAnyNumberFromZeroToOneLessThan(20)
 
-            val probabilityOfNotBackdatingAnEvent = 0 < randomBehaviour
-              .chooseAnyNumberFromZeroToOneLessThan(3)
+        val probabilityOfNotBackdatingAnEvent = 0 < randomBehaviour
+          .chooseAnyNumberFromZeroToOneLessThan(3)
 
-            val theHourFromTheStart =
-              if (probabilityOfNotBackdatingAnEvent) step
-              else
-                step - randomBehaviour
-                  .chooseAnyNumberFromOneTo(20)
+        val theHourFromTheStart =
+          if (probabilityOfNotBackdatingAnEvent) step
+          else
+            step - randomBehaviour
+              .chooseAnyNumberFromOneTo(20)
 
-            val idOffset = (step / idWindowSize) * idWindowSize
+        val idOffset = (step / idWindowSize) * idWindowSize
 
-            val probabilityOfBookingANewOrCorrectingEvent = 0 < randomBehaviour
-              .chooseAnyNumberFromZeroToOneLessThan(5)
+        val probabilityOfBookingANewOrCorrectingEvent = 0 < randomBehaviour
+          .chooseAnyNumberFromZeroToOneLessThan(5)
 
-            if (probabilityOfBookingANewOrCorrectingEvent) {
-              val oneId =
-                randomBehaviour.chooseOneOfRange(idSet.map(_ + idOffset))
+        if (probabilityOfBookingANewOrCorrectingEvent) {
+          val oneId =
+            randomBehaviour.chooseOneOfRange(idSet.map(_ + idOffset))
 
-              val anotherId =
-                randomBehaviour.chooseOneOfRange(idSet.map(_ + idOffset))
+          val anotherId =
+            randomBehaviour.chooseOneOfRange(idSet.map(_ + idOffset))
 
-              world.revise(
-                eventId,
-                Change.forTwoItems[Thing, Thing](
-                  Instant.ofEpochSecond(3600L * theHourFromTheStart)
-                )(
-                  oneId,
-                  anotherId,
-                  (oneThing, anotherThing) => {
-                    oneThing.property1 = step
-                    oneThing.referTo(anotherThing)
-                  }
-                ),
-                Instant.now()
-              )
-            } else {
-              world.annul(eventId, Instant.now())
-            }
-
-            val onePastQueryRevision =
-              randomBehaviour.chooseAnyNumberFromZeroToOneLessThan(
-                1 + world.nextRevision
-              )
-
-            val queryTime = Instant.ofEpochSecond(
-              3600L * randomBehaviour.chooseAnyNumberFromZeroToOneLessThan(
-                1 + theHourFromTheStart
-              )
-            )
-
-            val property1 = {
-              val scope = world.scopeFor(queryTime, onePastQueryRevision)
-
-              val queryId = randomBehaviour.chooseOneOfRange(
-                0 until (idOffset + idWindowSize)
-              )
-
-              scope
-                .render(Bitemporal.withId[Thing](queryId))
-                .toList
-                .headOption
-                .fold(-2)(_.property1)
-            }
-
-            if (step % 50 == 0) {
-              val currentTime = Deadline.now
-
-              val duration = currentTime - startTime
-
-              println(
-                s"Step: $step, duration: ${duration.toMillis} milliseconds, property1: $property1"
-              )
-            }
-          }
-
-          world // NASTY HACK - allow the world to escape the resource scope, so that memory footprints can be taken.
+          world.revise(
+            eventId,
+            Change.forTwoItems[Thing, Thing](
+              Instant.ofEpochSecond(3600L * theHourFromTheStart)
+            )(
+              oneId,
+              anotherId,
+              (oneThing, anotherThing) => {
+                oneThing.property1 = step
+                oneThing.referTo(anotherThing)
+              }
+            ),
+            Instant.now()
+          )
+        } else {
+          world.annul(eventId, Instant.now())
         }
-      )
 
-    world.unsafeRunSync()
+        val onePastQueryRevision =
+          randomBehaviour.chooseAnyNumberFromZeroToOneLessThan(
+            1 + world.nextRevision
+          )
+
+        val queryTime = Instant.ofEpochSecond(
+          3600L * randomBehaviour.chooseAnyNumberFromZeroToOneLessThan(
+            1 + theHourFromTheStart
+          )
+        )
+
+        val property1 = {
+          val scope = world.scopeFor(queryTime, onePastQueryRevision)
+
+          val queryId = randomBehaviour.chooseOneOfRange(
+            0 until (idOffset + idWindowSize)
+          )
+
+          scope
+            .render(Bitemporal.withId[Thing](queryId))
+            .toList
+            .headOption
+            .fold(-2)(_.property1)
+        }
+
+        if (step % 50 == 0) {
+          val currentTime = Deadline.now
+
+          val duration = currentTime - startTime
+
+          println(
+            s"Step: $step, duration: ${duration.toMillis} milliseconds, property1: $property1"
+          )
+        }
+      }
+
+      world // NASTY HACK - allow the world to escape the resource scope, so that memory footprints can be taken.
+    }
   }
 }
 

--- a/src/main/scala/com/sageserpent/plutonium/storage/BlobStorageOnH2.scala
+++ b/src/main/scala/com/sageserpent/plutonium/storage/BlobStorageOnH2.scala
@@ -1,8 +1,5 @@
 package com.sageserpent.plutonium.storage
 
-import cats.effect.unsafe.implicits.global
-import cats.effect.{IO, Resource}
-import cats.implicits._
 import com.esotericsoftware.kryo.kryo5.Kryo
 import com.esotericsoftware.kryo.kryo5.objenesis.strategy.StdInstantiatorStrategy
 import com.esotericsoftware.kryo.kryo5.util.{
@@ -27,6 +24,7 @@ import java.time.Instant
 import scala.collection.immutable.{SortedMap, TreeMap}
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
+import scala.util.Using
 
 //noinspection SqlNoDataSourceInspection
 object BlobStorageOnH2 {
@@ -72,19 +70,17 @@ object BlobStorageOnH2 {
       TreeMap.empty
     )
 
-  def setupDatabaseTables(connectionPool: ConnectionPool): IO[Unit] =
-    dbResource(connectionPool)
-      .use(db =>
-        IO {
-          db localTx { implicit session: DBSession =>
-            sql"""
+  def setupDatabaseTables(connectionPool: ConnectionPool): Unit =
+    Using.resource(DB(connectionPool.borrow())) { db =>
+      db localTx { implicit session: DBSession =>
+        sql"""
               CREATE TABLE Lineage(
                 LineageId       BIGINT  GENERATED ALWAYS AS IDENTITY (START WITH ${1 + sentinelLineageId}) PRIMARY KEY,
                 MaximumRevision INTEGER NOT NULL
               )
       """.update.apply()
 
-            sql"""
+        sql"""
               CREATE TABLE Snapshot(
                 ItemId                      VARBINARY         NOT NULL,
                 ItemClass                   VARBINARY         NOT NULL,
@@ -96,7 +92,7 @@ object BlobStorageOnH2 {
               )
       """.update.apply()
 
-            sql"""
+        sql"""
               CREATE TABLE TimeRevision(
                 Time                        BIGINT ARRAY      NOT NULL,
                 LineageId                   BIGINT            REFERENCES Lineage(LineageId),
@@ -105,19 +101,15 @@ object BlobStorageOnH2 {
               )
       """.update.apply()
 
-            sql"""
+        sql"""
               CREATE INDEX TLR ON Snapshot(Time, LineageId, Revision)
       """.update.apply()
 
-            sql"""
+        sql"""
               CREATE INDEX IIT ON Snapshot(ItemId, ItemClass, Time)
       """.update.apply()
-          }
-        }
-      )
-
-  private def dbResource(connectionPool: ConnectionPool): Resource[IO, DB] =
-    Resource.make(IO { DB(connectionPool.borrow()) })(db => IO { db.close() })
+      }
+    }
 
   def itemSql(
       uniqueItemSpecification: Option[UniqueItemSpecification]
@@ -320,92 +312,85 @@ case class BlobStorageOnH2(
       }
 
       override def build(): BlobStorage[ItemStateUpdateTime, SnapshotBlob] = {
-        (for {
-          newLineageEntry <- makeRevision()
-          (newLineageId, newRevision) = newLineageEntry
-        } yield {
-          if (newLineageId == thisBlobStorage.lineageId)
-            thisBlobStorage.copy(revision = newRevision)
-          else {
-            thisBlobStorage.copy(
-              lineageId = newLineageId,
-              revision = newRevision,
-              ancestralBranchpoints =
-                thisBlobStorage.ancestralBranchpoints + (thisBlobStorage.lineageId -> (
-                  thisBlobStorage.revision,
-                  None
-                ))
-            )
-          }
-        }).unsafeRunSync()
+        val newLineageEntry = makeRevision()
+        val (newLineageId, newRevision) = newLineageEntry
+        if (newLineageId == thisBlobStorage.lineageId)
+          thisBlobStorage.copy(revision = newRevision)
+        else {
+          thisBlobStorage.copy(
+            lineageId = newLineageId,
+            revision = newRevision,
+            ancestralBranchpoints =
+              thisBlobStorage.ancestralBranchpoints + (thisBlobStorage.lineageId -> (
+                thisBlobStorage.revision,
+                None
+              ))
+          )
+        }
       }
 
-      private def makeRevision(): IO[(LineageId, Revision)] =
-        BlobStorageOnH2
-          .dbResource(connectionPool)
-          .use(db =>
-            IO {
-              db localTx { implicit session: DBSession =>
-                // NOTE: the sentinel lineage id is always branched from, never
-                // extended; this works because there should be no entry in
-                // 'Lineage' using the sentinel lineage id.
-                val newOrReusedLineageId: LineageId = sql"""
+      private def makeRevision(): (LineageId, Revision) =
+        Using.resource(DB(connectionPool.borrow())) { db =>
+          db localTx { implicit session: DBSession =>
+            // NOTE: the sentinel lineage id is always branched from, never
+            // extended; this works because there should be no entry in
+            // 'Lineage' using the sentinel lineage id.
+            val newOrReusedLineageId: LineageId = sql"""
                    MERGE INTO Lineage
                     USING DUAL
                     ON LineageId = ? AND MaximumRevision = ?
                     WHEN MATCHED THEN UPDATE SET MaximumRevision = 1 + MaximumRevision
                     WHEN NOT MATCHED THEN INSERT (MaximumRevision) VALUES(?)
                    """
-                  .batchAndReturnGeneratedKey(
-                    "LineageId",
-                    Seq(lineageId, revision, initialRevision)
-                  )
-                  .apply[collection.Seq]()
-                  .headOption
-                  .getOrElse(lineageId)
+              .batchAndReturnGeneratedKey(
+                "LineageId",
+                Seq(lineageId, revision, initialRevision)
+              )
+              .apply[collection.Seq]()
+              .headOption
+              .getOrElse(lineageId)
 
-                val newRevision: Revision = sql"""
+            val newRevision: Revision = sql"""
                   SELECT MaximumRevision FROM Lineage WHERE LineageId = $newOrReusedLineageId
                   """.map(_.int(1)).single().get
 
-                for ((when, snapshotBlobs) <- recordings.toMap) {
-                  if (snapshotBlobs.nonEmpty) {
-                    for (
-                      (uniqueItemSpecification, snapshotBlob) <- snapshotBlobs
-                    ) {
-                      sql"""
+            for ((when, snapshotBlobs) <- recordings.toMap) {
+              if (snapshotBlobs.nonEmpty) {
+                for (
+                  (uniqueItemSpecification, snapshotBlob) <- snapshotBlobs
+                ) {
+                  sql"""
                           INSERT INTO Snapshot SET
                           ${itemSql(Some(uniqueItemSpecification))},
                           ${whenSql(when)},
                           ${lineageSql(newOrReusedLineageId, newRevision)},
                           ${snapshotSql(snapshotBlob)}
                          """.update()
-                    }
-                  } else {
-                    sql"""
+                }
+              } else {
+                sql"""
                           INSERT INTO Snapshot SET
                           ${itemSql(None)},
                           ${whenSql(when)},
                           ${lineageSql(newOrReusedLineageId, newRevision)},
                           ${snapshotSql(None)}
                          """.update()
-                  }
+              }
 
-                  sql"""
+              sql"""
                           INSERT INTO TimeRevision SET
                           ${whenSql(when)},
                           ${lineageSql(newOrReusedLineageId, newRevision)}
                          """.update()
-                }
-
-                assert(
-                  newOrReusedLineageId != lineageId || newRevision == 1 + revision
-                )
-
-                newOrReusedLineageId -> newRevision
-              }
             }
-          )
+
+            assert(
+              newOrReusedLineageId != lineageId || newRevision == 1 + revision
+            )
+
+            newOrReusedLineageId -> newRevision
+          }
+        }
     }
 
     new RevisionBuilderImplementation with RevisionBuilderContracts {
@@ -439,28 +424,23 @@ case class BlobStorageOnH2(
         val branchPoints =
           ancestralBranchpoints + (lineageId -> (revision -> None))
 
-        BlobStorageOnH2
-          .dbResource(connectionPool)
-          .use(db =>
-            IO {
-              db localTx { implicit session: DBSession =>
-                /* val explanation =
+        Using.resource(DB(connectionPool.borrow())) { db =>
+          db localTx { implicit session: DBSession =>
+            /* val explanation =
                  * sql"EXPLAIN ANALYZE ${matchingSnapshots(targetItemId,
                  * None)(branchPoints, when, includePayload = false,
                  * inclusive)}" .map(_.string(1)) .single() .apply
                  *
                  * println("Fetching unique item specifications...")
                  * println(explanation) */
-                sql"${matchingSnapshots(targetItemId, None)(branchPoints, when, includePayload = false, inclusive)}"
-                  .map(resultSet =>
-                    resultSet.bytes("ItemId")
-                      -> resultSet.bytes("ItemClass")
-                  )
-                  .list()
-              }
-            }
-          )
-          .unsafeRunSync()
+            sql"${matchingSnapshots(targetItemId, None)(branchPoints, when, includePayload = false, inclusive)}"
+              .map(resultSet =>
+                resultSet.bytes("ItemId")
+                  -> resultSet.bytes("ItemClass")
+              )
+              .list()
+          }
+        }
           .to(LazyList)
           .map { case (itemIdBytes, itemClazzBytes) =>
             val itemId =
@@ -484,12 +464,9 @@ case class BlobStorageOnH2(
         val branchPoints =
           ancestralBranchpoints + (lineageId -> (revision -> None))
 
-        BlobStorageOnH2
-          .dbResource(connectionPool)
-          .use(db =>
-            IO {
-              db localTx { implicit session: DBSession =>
-                /* val explanation =
+        Using.resource(DB(connectionPool.borrow())) { db =>
+          db localTx { implicit session: DBSession =>
+            /* val explanation =
                  * sql"EXPLAIN ANALYZE
                  * ${matchingSnapshots(Some(uniqueItemSpecification.id),
                  * Some(uniqueItemSpecification.clazz))(branchPoints, when,
@@ -497,13 +474,11 @@ case class BlobStorageOnH2(
                  * .single() .apply
                  *
                  * println("Fetching snapshot blob...") println(explanation) */
-                sql"${matchingSnapshots(Some(uniqueItemSpecification.id), Some(uniqueItemSpecification.clazz))(branchPoints, when, includePayload = true, inclusive)}"
-                  .map(resultSet => resultSet.bytes("Payload"))
-                  .list()
-              }
-            }
-          )
-          .unsafeRunSync()
+            sql"${matchingSnapshots(Some(uniqueItemSpecification.id), Some(uniqueItemSpecification.clazz))(branchPoints, when, includePayload = true, inclusive)}"
+              .map(resultSet => resultSet.bytes("Payload"))
+              .list()
+          }
+        }
           .to(LazyList)
           .map { payload =>
             assert(payload.nonEmpty)
@@ -517,39 +492,32 @@ case class BlobStorageOnH2(
   }
 
   override def retainUpTo(when: ItemStateUpdateTime): Timeline.BlobStorage = {
-    def makeRevision(): IO[(LineageId, Revision)] =
-      BlobStorageOnH2
-        .dbResource(connectionPool)
-        .use(db =>
-          IO {
-            db localTx { implicit session: DBSession =>
-              val newLineageId: LineageId = sql"""
+    def makeRevision(): (LineageId, Revision) =
+      Using.resource(DB(connectionPool.borrow())) { db =>
+        db localTx { implicit session: DBSession =>
+          val newLineageId: LineageId = sql"""
                    INSERT INTO Lineage (MaximumRevision) VALUES($initialRevision)
                     """
-                .updateAndReturnGeneratedKey("LineageId")
-                .apply()
+            .updateAndReturnGeneratedKey("LineageId")
+            .apply()
 
-              assert(newLineageId != lineageId)
+          assert(newLineageId != lineageId)
 
-              newLineageId -> initialRevision
-            }
-          }
-        )
+          newLineageId -> initialRevision
+        }
+      }
 
-    (for {
-      newLineageEntry <- makeRevision()
-      (newLineageId, newRevision) = newLineageEntry
-    } yield {
-      thisBlobStorage.copy(
-        lineageId = newLineageId,
-        revision = newRevision,
-        ancestralBranchpoints =
-          thisBlobStorage.ancestralBranchpoints + (thisBlobStorage.lineageId -> (
-            thisBlobStorage.revision,
-            Some(when)
-          ))
-      )
-    }).unsafeRunSync()
+    val newLineageEntry = makeRevision()
+    val (newLineageId, newRevision) = newLineageEntry
+    thisBlobStorage.copy(
+      lineageId = newLineageId,
+      revision = newRevision,
+      ancestralBranchpoints =
+        thisBlobStorage.ancestralBranchpoints + (thisBlobStorage.lineageId -> (
+          thisBlobStorage.revision,
+          Some(when)
+        ))
+    )
   }
 
 }

--- a/src/test/scala/com/sageserpent/plutonium/BitemporalBehaviours.scala
+++ b/src/test/scala/com/sageserpent/plutonium/BitemporalBehaviours.scala
@@ -1,10 +1,9 @@
 package com.sageserpent.plutonium
 
-import cats.effect.IO
-import cats.effect.unsafe.implicits.global
 import cats.kernel.laws.discipline.MonoidTests
 import cats.laws.discipline.MonadTests
 import cats.syntax.apply._
+import scala.util.Using
 import cats.{Applicative, Eq}
 import org.scalacheck.Prop.propBoolean
 import org.scalacheck.{Arbitrary, Gen, Prop, Properties}
@@ -63,9 +62,7 @@ trait BitemporalBehaviours
               asOfs,
               queryWhen
             ) =>
-          worldResource
-            .use(world =>
-              IO {
+          Using.resource(makeWorld()) { world =>
                 recordEventsInWorld(
                   bigShuffledHistoryOverLotsOfThings,
                   asOfs,
@@ -132,8 +129,6 @@ trait BitemporalBehaviours
 
                 Prop.all(properties.properties map (_._2) toSeq: _*)
               }
-            )
-            .unsafeRunSync
       })
     }
   }
@@ -181,9 +176,7 @@ trait BitemporalBehaviours
               asOfs,
               queryWhen
             ) =>
-          worldResource
-            .use(world =>
-              IO {
+          Using.resource(makeWorld()) { world =>
                 recordEventsInWorld(
                   bigShuffledHistoryOverLotsOfThings,
                   asOfs,
@@ -209,8 +202,6 @@ trait BitemporalBehaviours
 
                 (idsFromWildcardQuery == idsInExistence) :| s"${idsFromWildcardQuery} should be ${idsInExistence}, the items are: $itemsFromWildcardQuery"
               }
-            )
-            .unsafeRunSync
       })
     }
 
@@ -246,9 +237,7 @@ trait BitemporalBehaviours
       } yield (bigShuffledHistoryOverLotsOfThings, asOfs, queryWhen)
       check(Prop.forAllNoShrink(testCaseGenerator) {
         case (bigShuffledHistoryOverLotsOfThings, asOfs, queryWhen) =>
-          worldResource
-            .use(world =>
-              IO {
+          Using.resource(makeWorld()) { world =>
                 recordEventsInWorld(
                   bigShuffledHistoryOverLotsOfThings,
                   asOfs,
@@ -268,8 +257,6 @@ trait BitemporalBehaviours
                     } toSeq: _*
                 )
               }
-            )
-            .unsafeRunSync
       })
     }
   }
@@ -318,9 +305,7 @@ trait BitemporalBehaviours
               asOfs,
               queryWhen
             ) =>
-          worldResource
-            .use(world =>
-              IO {
+          Using.resource(makeWorld()) { world =>
                 recordEventsInWorld(
                   bigShuffledHistoryOverLotsOfThings,
                   asOfs,
@@ -368,8 +353,6 @@ trait BitemporalBehaviours
                   holdsFor[MoreSpecificFooHistory]
                 )
               }
-            )
-            .unsafeRunSync
       })
     }
 
@@ -416,9 +399,7 @@ trait BitemporalBehaviours
               asOfs,
               queryWhen
             ) =>
-          worldResource
-            .use(world =>
-              IO {
+          Using.resource(makeWorld()) { world =>
                 recordEventsInWorld(
                   bigShuffledHistoryOverLotsOfThings,
                   asOfs,
@@ -463,8 +444,6 @@ trait BitemporalBehaviours
                   holdsFor[MoreSpecificFooHistory]
                 )
               }
-            )
-            .unsafeRunSync
       })
     }
 
@@ -512,9 +491,7 @@ trait BitemporalBehaviours
               asOfs,
               queryWhen
             ) =>
-          worldResource
-            .use(world =>
-              IO {
+          Using.resource(makeWorld()) { world =>
                 recordEventsInWorld(
                   bigShuffledHistoryOverLotsOfThings,
                   asOfs,
@@ -561,8 +538,6 @@ trait BitemporalBehaviours
                   holdsFor[MoreSpecificFooHistory]
                 )
               }
-            )
-            .unsafeRunSync
       })
     }
 
@@ -610,9 +585,7 @@ trait BitemporalBehaviours
               asOfs,
               queryWhen
             ) =>
-          worldResource
-            .use(world =>
-              IO {
+          Using.resource(makeWorld()) { world =>
                 recordEventsInWorld(
                   bigShuffledHistoryOverLotsOfThings,
                   asOfs,
@@ -666,8 +639,6 @@ trait BitemporalBehaviours
                   holdsFor[MoreSpecificFooHistory]
                 )
               }
-            )
-            .unsafeRunSync
       })
     }
   }
@@ -716,9 +687,7 @@ trait BitemporalBehaviours
               asOfs,
               queryWhen
             ) =>
-          worldResource
-            .use(world =>
-              IO {
+          Using.resource(makeWorld()) { world =>
                 recordEventsInWorld(
                   bigShuffledHistoryOverLotsOfThings,
                   asOfs,
@@ -762,8 +731,6 @@ trait BitemporalBehaviours
                   holdsFor[MoreSpecificFooHistory]
                 )
               }
-            )
-            .unsafeRunSync
       })
     }
   }
@@ -806,9 +773,7 @@ trait BitemporalBehaviours
       )
       check(Prop.forAllNoShrink(testCaseGenerator) {
         case (_, bigShuffledHistoryOverLotsOfThings, asOfs, queryWhen) =>
-          worldResource
-            .use(world =>
-              IO {
+          Using.resource(makeWorld()) { world =>
                 recordEventsInWorld(
                   bigShuffledHistoryOverLotsOfThings,
                   asOfs,
@@ -821,8 +786,6 @@ trait BitemporalBehaviours
                   .render(Bitemporal.none)
                   .isEmpty :| "scope.render(Bitemporal.none).isEmpty"
               }
-            )
-            .unsafeRunSync
       })
     }
   }
@@ -870,9 +833,7 @@ trait BitemporalBehaviours
               asOfs,
               queryWhen
             ) =>
-          worldResource
-            .use(world =>
-              IO {
+          Using.resource(makeWorld()) { world =>
                 recordEventsInWorld(
                   bigShuffledHistoryOverLotsOfThings,
                   asOfs,
@@ -945,8 +906,6 @@ trait BitemporalBehaviours
                   Prop.all(wildcardProperty, genericQueryByIdProperty)
                 } else Prop.undecided
               }
-            )
-            .unsafeRunSync
       })
     }
 
@@ -993,9 +952,7 @@ trait BitemporalBehaviours
               asOfs,
               queryWhen
             ) =>
-          worldResource
-            .use(world =>
-              IO {
+          Using.resource(makeWorld()) { world =>
                 recordEventsInWorld(
                   bigShuffledHistoryOverLotsOfThings,
                   asOfs,
@@ -1040,8 +997,6 @@ trait BitemporalBehaviours
                   )
                 } else Prop.undecided
               }
-            )
-            .unsafeRunSync
       })
     }
   }

--- a/src/test/scala/com/sageserpent/plutonium/Bugs.scala
+++ b/src/test/scala/com/sageserpent/plutonium/Bugs.scala
@@ -1,7 +1,7 @@
 package com.sageserpent.plutonium
 
-import cats.effect.IO
-import cats.effect.unsafe.implicits.global
+import scala.util.Using
+
 import cats.syntax.apply._
 import com.sageserpent.americium.utilities.randomEnrichment._
 import com.sageserpent.plutonium.utilities.{NegativeInfinity, PositiveInfinity}
@@ -40,63 +40,59 @@ trait Bugs
 
       val sharedAsOf = Instant.ofEpochSecond(0)
 
-      worldResource
-        .use(world =>
-          IO {
-            world.revise(
-              Map(
-                eventBeingRevised -> Some(
-                  Change
-                    .forOneItem[IntegerHistory](timeOfObsoleteEvent)(
-                      firstItemId,
-                      { item =>
-                        item.integerProperty = 734634
-                      }
-                    )
+      Using.resource(makeWorld()) { world =>
+        world.revise(
+          Map(
+            eventBeingRevised -> Some(
+              Change
+                .forOneItem[IntegerHistory](timeOfObsoleteEvent)(
+                  firstItemId,
+                  { item =>
+                    item.integerProperty = 734634
+                  }
                 )
-              ),
-              sharedAsOf
             )
-
-            world.revise(
-              Map(
-                firstFinalEventForFirstItem -> Some(
-                  Change
-                    .forOneItem[IntegerHistory](
-                      timeOfObsoleteEvent plusMillis 1
-                    )(
-                      firstItemId,
-                      { item =>
-                        item.integerProperty = expectedFinalValue
-                      }
-                    )
-                ),
-                eventBeingRevised ->
-                  Some(
-                    Change
-                      .forOneItem[MoreSpecificFooHistory](
-                        timeOfObsoleteEvent plusMillis 2
-                      )(
-                        secondItemId,
-                        { item =>
-                          item.property1 = "Kingston Bagpuize"
-                        }
-                      )
-                  )
-              ),
-              sharedAsOf
-            )
-
-            val scope =
-              world.scopeFor(PositiveInfinity, world.nextRevision)
-
-            scope
-              .render(Bitemporal.withId[IntegerHistory](firstItemId))
-              .loneElement
-              .datums should contain theSameElementsAs Seq(expectedFinalValue)
-          }
+          ),
+          sharedAsOf
         )
-        .unsafeRunSync
+
+        world.revise(
+          Map(
+            firstFinalEventForFirstItem -> Some(
+              Change
+                .forOneItem[IntegerHistory](
+                  timeOfObsoleteEvent plusMillis 1
+                )(
+                  firstItemId,
+                  { item =>
+                    item.integerProperty = expectedFinalValue
+                  }
+                )
+            ),
+            eventBeingRevised ->
+              Some(
+                Change
+                  .forOneItem[MoreSpecificFooHistory](
+                    timeOfObsoleteEvent plusMillis 2
+                  )(
+                    secondItemId,
+                    { item =>
+                      item.property1 = "Kingston Bagpuize"
+                    }
+                  )
+              )
+          ),
+          sharedAsOf
+        )
+
+        val scope =
+          world.scopeFor(PositiveInfinity, world.nextRevision)
+
+        scope
+          .render(Bitemporal.withId[IntegerHistory](firstItemId))
+          .loneElement
+          .datums should contain theSameElementsAs Seq(expectedFinalValue)
+      }
     }
 
     "events that have been revised" should "no longer contribute history to an item, even when the revised event refers to another item - with a twist" in {
@@ -115,61 +111,57 @@ trait Bugs
 
       val sharedAsOf = Instant.ofEpochSecond(0)
 
-      worldResource
-        .use(world =>
-          IO {
-            world.revise(
-              Map(
-                firstFinalEventForFirstItem -> Some(
-                  Change
-                    .forOneItem[IntegerHistory](
-                      sharedTimeOfFinalAndObsoleteEvent
-                    )(
-                      firstItemId,
-                      { item =>
-                        item.integerProperty = expectedFinalValue
-                      }
-                    )
-                ),
-                eventBeingRevised -> Some(
-                  Change
-                    .forOneItem[IntegerHistory](
-                      sharedTimeOfFinalAndObsoleteEvent
-                    )(
-                      firstItemId,
-                      { item =>
-                        item.integerProperty = 734634
-                      }
-                    )
-                )
-              ),
-              sharedAsOf
-            )
-
-            world.revise(
-              eventBeingRevised,
+      Using.resource(makeWorld()) { world =>
+        world.revise(
+          Map(
+            firstFinalEventForFirstItem -> Some(
               Change
-                .forOneItem[MoreSpecificFooHistory](
-                  sharedTimeOfFinalAndObsoleteEvent plusMillis 1
+                .forOneItem[IntegerHistory](
+                  sharedTimeOfFinalAndObsoleteEvent
                 )(
-                  secondItemId,
+                  firstItemId,
                   { item =>
-                    item.property1 = "Kingston Bagpuize"
+                    item.integerProperty = expectedFinalValue
                   }
-                ),
-              sharedAsOf
+                )
+            ),
+            eventBeingRevised -> Some(
+              Change
+                .forOneItem[IntegerHistory](
+                  sharedTimeOfFinalAndObsoleteEvent
+                )(
+                  firstItemId,
+                  { item =>
+                    item.integerProperty = 734634
+                  }
+                )
             )
-
-            val scope =
-              world.scopeFor(PositiveInfinity, world.nextRevision)
-
-            scope
-              .render(Bitemporal.withId[IntegerHistory](firstItemId))
-              .loneElement
-              .datums should contain theSameElementsAs Seq(expectedFinalValue)
-          }
+          ),
+          sharedAsOf
         )
-        .unsafeRunSync
+
+        world.revise(
+          eventBeingRevised,
+          Change
+            .forOneItem[MoreSpecificFooHistory](
+              sharedTimeOfFinalAndObsoleteEvent plusMillis 1
+            )(
+              secondItemId,
+              { item =>
+                item.property1 = "Kingston Bagpuize"
+              }
+            ),
+          sharedAsOf
+        )
+
+        val scope =
+          world.scopeFor(PositiveInfinity, world.nextRevision)
+
+        scope
+          .render(Bitemporal.withId[IntegerHistory](firstItemId))
+          .loneElement
+          .datums should contain theSameElementsAs Seq(expectedFinalValue)
+      }
     }
 
     "events that have the same effect on an item" should "be applicable across several item lifecycles, even if the item unified type changes" in {
@@ -179,98 +171,94 @@ trait Bugs
 
       val commonValue = "Foo"
 
-      worldResource
-        .use(world =>
-          IO {
-            {
-              world.revise(
-                0,
-                Change.forOneItem[FooHistory](Instant.ofEpochSecond(0L))(
-                  lizId,
-                  { liz =>
-                    liz.property1 = commonValue
-                  }
-                ),
-                sharedAsOf
-              )
+      Using.resource(makeWorld()) { world =>
+        {
+          world.revise(
+            0,
+            Change.forOneItem[FooHistory](Instant.ofEpochSecond(0L))(
+              lizId,
+              { liz =>
+                liz.property1 = commonValue
+              }
+            ),
+            sharedAsOf
+          )
 
-              world.revise(
-                1,
-                Annihilation[MoreSpecificFooHistory](
-                  Instant.ofEpochSecond(1L),
-                  lizId
-                ),
-                sharedAsOf
-              )
-            }
+          world.revise(
+            1,
+            Annihilation[MoreSpecificFooHistory](
+              Instant.ofEpochSecond(1L),
+              lizId
+            ),
+            sharedAsOf
+          )
+        }
 
-            {
-              world.revise(
-                2,
-                Change.forOneItem[FooHistory](Instant.ofEpochSecond(2L))(
-                  lizId,
-                  { liz =>
-                    liz.property1 = commonValue
-                  }
-                ),
-                sharedAsOf
-              )
+        {
+          world.revise(
+            2,
+            Change.forOneItem[FooHistory](Instant.ofEpochSecond(2L))(
+              lizId,
+              { liz =>
+                liz.property1 = commonValue
+              }
+            ),
+            sharedAsOf
+          )
 
-              world.revise(
-                3,
-                Annihilation[AnotherSpecificFooHistory](
-                  Instant.ofEpochSecond(3L),
-                  lizId
-                ),
-                sharedAsOf
-              )
-            }
+          world.revise(
+            3,
+            Annihilation[AnotherSpecificFooHistory](
+              Instant.ofEpochSecond(3L),
+              lizId
+            ),
+            sharedAsOf
+          )
+        }
 
-            {
-              world.revise(
-                4,
-                Change.forOneItem[FooHistory](Instant.ofEpochSecond(4L))(
-                  lizId,
-                  { liz =>
-                    liz.property1 = commonValue
-                  }
-                ),
-                sharedAsOf
-              )
+        {
+          world.revise(
+            4,
+            Change.forOneItem[FooHistory](Instant.ofEpochSecond(4L))(
+              lizId,
+              { liz =>
+                liz.property1 = commonValue
+              }
+            ),
+            sharedAsOf
+          )
 
-              world.revise(
-                5,
-                Annihilation[FooHistory](Instant.ofEpochSecond(5L), lizId),
-                sharedAsOf
-              )
-            }
+          world.revise(
+            5,
+            Annihilation[FooHistory](Instant.ofEpochSecond(5L), lizId),
+            sharedAsOf
+          )
+        }
 
-            {
-              world
-                .scopeFor(Instant.ofEpochSecond(0L), sharedAsOf)
-                .render(Bitemporal.withId[MoreSpecificFooHistory](lizId))
-                .loneElement
-                .datums should contain theSameElementsAs List(commonValue)
-            }
+        {
+          world
+            .scopeFor(Instant.ofEpochSecond(0L), sharedAsOf)
+            .render(Bitemporal.withId[MoreSpecificFooHistory](lizId))
+            .loneElement
+            .datums should contain theSameElementsAs List(commonValue)
+        }
 
-            {
-              world
-                .scopeFor(Instant.ofEpochSecond(2L), sharedAsOf)
-                .render(Bitemporal.withId[AnotherSpecificFooHistory](lizId))
-                .loneElement
-                .datums should contain theSameElementsAs List(commonValue)
-            }
+        {
+          world
+            .scopeFor(Instant.ofEpochSecond(2L), sharedAsOf)
+            .render(Bitemporal.withId[AnotherSpecificFooHistory](lizId))
+            .loneElement
+            .datums should contain theSameElementsAs List(commonValue)
+        }
 
-            {
-              world
-                .scopeFor(Instant.ofEpochSecond(4L), sharedAsOf)
-                .render(Bitemporal.withId[FooHistory](lizId))
-                .loneElement
-                .datums should contain theSameElementsAs List(commonValue)
-            }
-          }
-        )
-        .unsafeRunSync
+        {
+          world
+            .scopeFor(Instant.ofEpochSecond(4L), sharedAsOf)
+            .render(Bitemporal.withId[FooHistory](lizId))
+            .loneElement
+            .datums should contain theSameElementsAs List(commonValue)
+        }
+      }
     }
 
     "a related item that was annihilated where that item is resurrected just after it is annihilated" should "be detected as a ghost by an event that attempts to mutate it" in {
@@ -285,61 +273,57 @@ trait Bugs
 
       val sharedAsOf = Instant.ofEpochSecond(0)
 
-      worldResource
-        .use(world =>
-          IO {
-            world.revise(
-              1,
-              Change.forTwoItems[ReferringHistory, FooHistory](
-                startOfRelationship
-              )(
-                referrerId,
-                referredId,
-                { (referrer, referred) =>
-                  referrer.referTo(referred)
-                }
-              ),
-              sharedAsOf
-            )
-            world.revise(
-              2,
-              Annihilation[FooHistory](
-                whenAnnihilationAndResurrectionTakesPlace,
-                referredId
-              ),
-              sharedAsOf
-            )
-            world.revise(
-              3,
-              Change.forOneItem[FooHistory](
-                whenAnnihilationAndResurrectionTakesPlace
-              )(
-                referredId,
-                { referred =>
-                  referred.property1 = "Hello"
-                }
-              ),
-              sharedAsOf
-            )
-            intercept[RuntimeException] {
-              world.revise(
-                4,
-                Change.forOneItem[ReferringHistory](
-                  whenAnnihilationAndResurrectionTakesPlace
-                )(
-                  referrerId,
-                  { referrer =>
-                    referrer.mutateRelatedItem(
-                      referredId.asInstanceOf[History#Id]
-                    )
-                  }
-                ),
-                sharedAsOf
-              )
+      Using.resource(makeWorld()) { world =>
+        world.revise(
+          1,
+          Change.forTwoItems[ReferringHistory, FooHistory](
+            startOfRelationship
+          )(
+            referrerId,
+            referredId,
+            { (referrer, referred) =>
+              referrer.referTo(referred)
             }
-          }
+          ),
+          sharedAsOf
         )
-        .unsafeRunSync
+        world.revise(
+          2,
+          Annihilation[FooHistory](
+            whenAnnihilationAndResurrectionTakesPlace,
+            referredId
+          ),
+          sharedAsOf
+        )
+        world.revise(
+          3,
+          Change.forOneItem[FooHistory](
+            whenAnnihilationAndResurrectionTakesPlace
+          )(
+            referredId,
+            { referred =>
+              referred.property1 = "Hello"
+            }
+          ),
+          sharedAsOf
+        )
+        intercept[RuntimeException] {
+          world.revise(
+            4,
+            Change.forOneItem[ReferringHistory](
+              whenAnnihilationAndResurrectionTakesPlace
+            )(
+              referrerId,
+              { referrer =>
+                referrer.mutateRelatedItem(
+                  referredId.asInstanceOf[History#Id]
+                )
+              }
+            ),
+            sharedAsOf
+          )
+        }
+      }
     }
 
     "a related item that was annihilated where that item is resurrected just after it is annihilated" should "be detected as a ghost by an event that attempts to mutate it - with a twist" in {
@@ -354,62 +338,58 @@ trait Bugs
 
       val sharedAsOf = Instant.ofEpochSecond(0)
 
-      worldResource
-        .use(world =>
-          IO {
-            world.revise(
-              1,
-              Change.forTwoItems[ReferringHistory, FooHistory](
-                startOfRelationship
-              )(
-                referrerId,
-                referredId,
-                { (referrer, referred) =>
-                  referrer.referTo(referred)
-                }
-              ),
-              sharedAsOf
-            )
-            world.revise(
-              Map(
-                2 -> Some(
-                  Annihilation[FooHistory](
-                    whenAnnihilationAndResurrectionTakesPlace,
-                    referredId
-                  )
-                ),
-                3 -> Some(
-                  Change.forOneItem[FooHistory](
-                    whenAnnihilationAndResurrectionTakesPlace
-                  )(
-                    referredId,
-                    { referred =>
-                      referred.property1 = "Hello"
-                    }
-                  )
-                )
-              ),
-              sharedAsOf
-            )
-            intercept[RuntimeException] {
-              world.revise(
-                4,
-                Change.forOneItem[ReferringHistory](
-                  whenAnnihilationAndResurrectionTakesPlace
-                )(
-                  referrerId,
-                  { referrer =>
-                    referrer.mutateRelatedItem(
-                      referredId.asInstanceOf[History#Id]
-                    )
-                  }
-                ),
-                sharedAsOf
-              )
+      Using.resource(makeWorld()) { world =>
+        world.revise(
+          1,
+          Change.forTwoItems[ReferringHistory, FooHistory](
+            startOfRelationship
+          )(
+            referrerId,
+            referredId,
+            { (referrer, referred) =>
+              referrer.referTo(referred)
             }
-          }
+          ),
+          sharedAsOf
         )
-        .unsafeRunSync
+        world.revise(
+          Map(
+            2 -> Some(
+              Annihilation[FooHistory](
+                whenAnnihilationAndResurrectionTakesPlace,
+                referredId
+              )
+            ),
+            3 -> Some(
+              Change.forOneItem[FooHistory](
+                whenAnnihilationAndResurrectionTakesPlace
+              )(
+                referredId,
+                { referred =>
+                  referred.property1 = "Hello"
+                }
+              )
+            )
+          ),
+          sharedAsOf
+        )
+        intercept[RuntimeException] {
+          world.revise(
+            4,
+            Change.forOneItem[ReferringHistory](
+              whenAnnihilationAndResurrectionTakesPlace
+            )(
+              referrerId,
+              { referrer =>
+                referrer.mutateRelatedItem(
+                  referredId.asInstanceOf[History#Id]
+                )
+              }
+            ),
+            sharedAsOf
+          )
+        }
+      }
     }
 
     "booking in simple changes in the same single revision" should "work" in {
@@ -422,48 +402,44 @@ trait Bugs
       val barChangeWhen = Instant.ofEpochSecond(0L)
       val fooChangeWhen = barChangeWhen plusSeconds 1L
 
-      worldResource
-        .use(world =>
-          IO {
-            world.revise(
-              Map(
-                0 -> Some(
-                  Change.forOneItem(barChangeWhen)(
-                    barId,
-                    { bar: BarHistory =>
-                      bar.property1 = -7.81198542653286e87
-                    }
-                  )
-                ),
-                1 -> Some(
-                  Change.forOneItem(fooChangeWhen)(
-                    fooId,
-                    { foo: FooHistory =>
-                      foo.property2 = true
-                    }
-                  )
-                )
-              ),
-              asOf
+      Using.resource(makeWorld()) { world =>
+        world.revise(
+          Map(
+            0 -> Some(
+              Change.forOneItem(barChangeWhen)(
+                barId,
+                { bar: BarHistory =>
+                  bar.property1 = -7.81198542653286e87
+                }
+              )
+            ),
+            1 -> Some(
+              Change.forOneItem(fooChangeWhen)(
+                fooId,
+                { foo: FooHistory =>
+                  foo.property2 = true
+                }
+              )
             )
-
-            val scope =
-              world.scopeFor(fooChangeWhen, asOf)
-
-            scope
-              .render(Bitemporal.withId[BarHistory](barId))
-              .loneElement
-              .datums should contain theSameElementsInOrderAs Seq(
-              -7.81198542653286e87
-            )
-
-            scope
-              .render(Bitemporal.withId[FooHistory](fooId))
-              .loneElement
-              .datums should contain theSameElementsInOrderAs Seq(true)
-          }
+          ),
+          asOf
         )
-        .unsafeRunSync
+
+        val scope =
+          world.scopeFor(fooChangeWhen, asOf)
+
+        scope
+          .render(Bitemporal.withId[BarHistory](barId))
+          .loneElement
+          .datums should contain theSameElementsInOrderAs Seq(
+          -7.81198542653286e87
+        )
+
+        scope
+          .render(Bitemporal.withId[FooHistory](fooId))
+          .loneElement
+          .datums should contain theSameElementsInOrderAs Seq(true)
+      }
     }
 
     "booking in events in reverse order of physical time" should "work" in {
@@ -473,41 +449,37 @@ trait Bugs
 
       val expectedHistory = Seq("The Real Thing", true)
 
-      worldResource
-        .use(world =>
-          IO {
-            world.revise(
-              0,
-              Change.forOneItem(Instant.ofEpochSecond(1L))(
-                itemId,
-                { item: FooHistory =>
-                  item.property2 = true
-                }
-              ),
-              sharedAsOf
-            )
-
-            world.revise(
-              1,
-              Change.forOneItem(Instant.ofEpochSecond(0L))(
-                itemId,
-                { item: FooHistory =>
-                  item.property1 = "The Real Thing"
-                }
-              ),
-              sharedAsOf
-            )
-
-            val scope =
-              world.scopeFor(PositiveInfinity, world.nextRevision)
-
-            scope
-              .render(Bitemporal.withId[FooHistory](itemId))
-              .loneElement
-              .datums should contain theSameElementsInOrderAs expectedHistory
-          }
+      Using.resource(makeWorld()) { world =>
+        world.revise(
+          0,
+          Change.forOneItem(Instant.ofEpochSecond(1L))(
+            itemId,
+            { item: FooHistory =>
+              item.property2 = true
+            }
+          ),
+          sharedAsOf
         )
-        .unsafeRunSync
+
+        world.revise(
+          1,
+          Change.forOneItem(Instant.ofEpochSecond(0L))(
+            itemId,
+            { item: FooHistory =>
+              item.property1 = "The Real Thing"
+            }
+          ),
+          sharedAsOf
+        )
+
+        val scope =
+          world.scopeFor(PositiveInfinity, world.nextRevision)
+
+        scope
+          .render(Bitemporal.withId[FooHistory](itemId))
+          .loneElement
+          .datums should contain theSameElementsInOrderAs expectedHistory
+      }
     }
 
     "annihilating an item" should "not affect events occurring in a subsequent lifecycle" in {
@@ -517,58 +489,54 @@ trait Bugs
 
       val expectedHistory = Seq(1, 2)
 
-      worldResource
-        .use(world =>
-          IO {
-            world.revise(
-              0,
-              Change.forOneItem(Instant.ofEpochSecond(0L))(
-                itemId,
-                { item: IntegerHistory =>
-                  item.integerProperty = -999
-                }
-              ),
-              sharedAsOf
-            )
-
-            world.revise(
-              1,
-              Annihilation[IntegerHistory](Instant.ofEpochSecond(1L), itemId),
-              sharedAsOf
-            )
-
-            world.revise(
-              2,
-              Change.forOneItem(Instant.ofEpochSecond(3L))(
-                itemId,
-                { item: IntegerHistory =>
-                  item.integerProperty = 2
-                }
-              ),
-              sharedAsOf
-            )
-
-            world.revise(
-              3,
-              Change.forOneItem(Instant.ofEpochSecond(2L))(
-                itemId,
-                { item: IntegerHistory =>
-                  item.integerProperty = 1
-                }
-              ),
-              sharedAsOf
-            )
-
-            val scope =
-              world.scopeFor(PositiveInfinity, world.nextRevision)
-
-            scope
-              .render(Bitemporal.withId[IntegerHistory](itemId))
-              .loneElement
-              .datums should contain theSameElementsInOrderAs expectedHistory
-          }
+      Using.resource(makeWorld()) { world =>
+        world.revise(
+          0,
+          Change.forOneItem(Instant.ofEpochSecond(0L))(
+            itemId,
+            { item: IntegerHistory =>
+              item.integerProperty = -999
+            }
+          ),
+          sharedAsOf
         )
-        .unsafeRunSync
+
+        world.revise(
+          1,
+          Annihilation[IntegerHistory](Instant.ofEpochSecond(1L), itemId),
+          sharedAsOf
+        )
+
+        world.revise(
+          2,
+          Change.forOneItem(Instant.ofEpochSecond(3L))(
+            itemId,
+            { item: IntegerHistory =>
+              item.integerProperty = 2
+            }
+          ),
+          sharedAsOf
+        )
+
+        world.revise(
+          3,
+          Change.forOneItem(Instant.ofEpochSecond(2L))(
+            itemId,
+            { item: IntegerHistory =>
+              item.integerProperty = 1
+            }
+          ),
+          sharedAsOf
+        )
+
+        val scope =
+          world.scopeFor(PositiveInfinity, world.nextRevision)
+
+        scope
+          .render(Bitemporal.withId[IntegerHistory](itemId))
+          .loneElement
+          .datums should contain theSameElementsInOrderAs expectedHistory
+      }
     }
 
     "forgetting to supply a type tag when annihilating an item" should "result in a useful diagnostic" in {
@@ -576,32 +544,28 @@ trait Bugs
 
       val sharedAsOf = Instant.ofEpochSecond(0)
 
-      worldResource
-        .use(world =>
-          IO {
-            world.revise(
-              0,
-              Change.forOneItem(Instant.ofEpochSecond(0L))(
-                itemId,
-                { item: IntegerHistory =>
-                  item.integerProperty = 1
-                }
-              ),
-              sharedAsOf
-            )
-
-            val exception = intercept[RuntimeException] {
-              world.revise(
-                1,
-                Annihilation(Instant.ofEpochSecond(1L), itemId),
-                sharedAsOf
-              )
+      Using.resource(makeWorld()) { world =>
+        world.revise(
+          0,
+          Change.forOneItem(Instant.ofEpochSecond(0L))(
+            itemId,
+            { item: IntegerHistory =>
+              item.integerProperty = 1
             }
-
-            exception.getMessage should include regex "attempt to annihilate an item.*without an explicit type"
-          }
+          ),
+          sharedAsOf
         )
-        .unsafeRunSync
+
+        val exception = intercept[RuntimeException] {
+          world.revise(
+            1,
+            Annihilation(Instant.ofEpochSecond(1L), itemId),
+            sharedAsOf
+          )
+        }
+
+        exception.getMessage should include regex "attempt to annihilate an item.*without an explicit type"
+      }
     }
 
     "annihilating an item and then resurrecting it at the same physical time" should "result in a history for the resurrected item" in {
@@ -651,31 +615,6 @@ trait Bugs
         changeFor(secondReferringId, Instant.ofEpochSecond(-1L), "Louie")
       )
 
-      /* worldResource.use(world => IO{ world.revise(Map( 0 -> Some(
-       * changeFor(secondReferringId, Instant.ofEpochSecond(-4L), "Huey"))),
-       * sharedAsOf)
-       *
-       * world.revise( Map( 1 -> Some( changeFor(firstReferringId,
-       * Instant.ofEpochSecond(0L), "Louie")), 2 -> Some(
-       * annihilationFor(firstReferringId, Instant.ofEpochSecond(0L)))),
-       * sharedAsOf )
-       *
-       * world.revise( Map( 3 -> Some( changeFor(firstReferringId,
-       * Instant.ofEpochSecond(0L), "Duey")), 4 -> Some(
-       * annihilationFor(secondReferringId, Instant.ofEpochSecond(-3L))), 5 ->
-       * Some( changeFor(secondReferringId, Instant.ofEpochSecond(-2L), "Huey"))
-       * ), sharedAsOf )
-       *
-       * world.revise(Map( 6 -> Some( changeFor(secondReferringId,
-       * Instant.ofEpochSecond(-1L), "Louie")) ), sharedAsOf)
-       *
-       * val scope =
-       * world.scopeFor(Instant.ofEpochSecond(0L), world.nextRevision)
-       *
-       * scope .render(Bitemporal.withId[ReferringHistory](firstReferringId))
-       * .loneElement .referencedDatums .toSeq should contain theSameElementsAs
-       * Seq("Duey" -> Seq.empty) } */
-
       for (seed <- 1 to 100) {
         val randomBehaviour = new Random(seed)
 
@@ -686,40 +625,36 @@ trait Bugs
         val eventsInChunks = randomBehaviour
           .splitIntoNonEmptyPieces(eventsForBothItems.zipWithIndex)
 
-        worldResource
-          .use(world =>
-            IO {
-              for (eventChunk <- eventsInChunks) {
-                world.revise(
-                  SortedMap(eventChunk.map { case (event, eventId) =>
-                    eventId -> Some(event)
-                  }: _*),
-                  sharedAsOf
-                )
-              }
+        Using.resource(makeWorld()) { world =>
+          for (eventChunk <- eventsInChunks) {
+            world.revise(
+              SortedMap(eventChunk.map { case (event, eventId) =>
+                eventId -> Some(event)
+              }: _*),
+              sharedAsOf
+            )
+          }
 
-              val scope =
-                world.scopeFor(Instant.ofEpochSecond(0L), world.nextRevision)
+          val scope =
+            world.scopeFor(Instant.ofEpochSecond(0L), world.nextRevision)
 
-              try {
-                scope
-                  .render(Bitemporal.withId[ReferringHistory](firstReferringId))
-                  .loneElement
-                  .referencedDatums
-                  .toSeq should contain theSameElementsAs Seq(
-                  "Duey" -> Seq.empty
+          try {
+            scope
+              .render(Bitemporal.withId[ReferringHistory](firstReferringId))
+              .loneElement
+              .referencedDatums
+              .toSeq should contain theSameElementsAs Seq(
+              "Duey" -> Seq.empty
+            )
+          } catch {
+            case exception: TestFailedException =>
+              throw exception.modifyMessage(
+                _.map(message =>
+                  s"$message - Test case is: $eventsInChunks"
                 )
-              } catch {
-                case exception: TestFailedException =>
-                  throw exception.modifyMessage(
-                    _.map(message =>
-                      s"$message - Test case is: $eventsInChunks"
-                    )
-                  )
-              }
-            }
-          )
-          .unsafeRunSync
+              )
+          }
+        }
       }
     }
     "correcting an event by moving it in physical time" should "work properly" in {
@@ -731,66 +666,62 @@ trait Bugs
 
       val eventBeingMovedInPhysicalTime = 1
 
-      worldResource
-        .use(world =>
-          IO {
-            world.revise(
-              0,
-              Change.forOneItem(Instant.ofEpochSecond(-3L))(
-                itemId,
-                { item: IntegerHistory =>
-                  item.integerProperty = 99
-                }
-              ),
-              sharedAsOf
-            )
-
-            val foo = (item: IntegerHistory) => item.integerProperty = 55555
-
-            world.revise(
-              eventBeingMovedInPhysicalTime,
-              Change.forOneItem(Instant.ofEpochSecond(1L))(itemId, foo),
-              sharedAsOf
-            )
-
-            world.revise(
-              2,
-              Change.forOneItem(Instant.ofEpochSecond(0L))(
-                itemId,
-                { item: IntegerHistory =>
-                  item.integerProperty = 77
-                }
-              ),
-              sharedAsOf
-            )
-
-            world.revise(
-              Map(
-                eventBeingMovedInPhysicalTime -> Some(
-                  Change.forOneItem(Instant.ofEpochSecond(-1L))(itemId, foo)
-                ),
-                3 -> Some(
-                  Change.forOneItem(Instant.ofEpochSecond(-2L))(
-                    itemId,
-                    { item: IntegerHistory =>
-                      item.integerProperty = 88
-                    }
-                  )
-                )
-              ),
-              sharedAsOf
-            )
-
-            val scope =
-              world.scopeFor(PositiveInfinity, world.nextRevision)
-
-            scope
-              .render(Bitemporal.withId[IntegerHistory](itemId))
-              .loneElement
-              .datums should contain theSameElementsInOrderAs expectedHistory
-          }
+      Using.resource(makeWorld()) { world =>
+        world.revise(
+          0,
+          Change.forOneItem(Instant.ofEpochSecond(-3L))(
+            itemId,
+            { item: IntegerHistory =>
+              item.integerProperty = 99
+            }
+          ),
+          sharedAsOf
         )
-        .unsafeRunSync
+
+        val foo = (item: IntegerHistory) => item.integerProperty = 55555
+
+        world.revise(
+          eventBeingMovedInPhysicalTime,
+          Change.forOneItem(Instant.ofEpochSecond(1L))(itemId, foo),
+          sharedAsOf
+        )
+
+        world.revise(
+          2,
+          Change.forOneItem(Instant.ofEpochSecond(0L))(
+            itemId,
+            { item: IntegerHistory =>
+              item.integerProperty = 77
+            }
+          ),
+          sharedAsOf
+        )
+
+        world.revise(
+          Map(
+            eventBeingMovedInPhysicalTime -> Some(
+              Change.forOneItem(Instant.ofEpochSecond(-1L))(itemId, foo)
+            ),
+            3 -> Some(
+              Change.forOneItem(Instant.ofEpochSecond(-2L))(
+                itemId,
+                { item: IntegerHistory =>
+                  item.integerProperty = 88
+                }
+              )
+            )
+          ),
+          sharedAsOf
+        )
+
+        val scope =
+          world.scopeFor(PositiveInfinity, world.nextRevision)
+
+        scope
+          .render(Bitemporal.withId[IntegerHistory](itemId))
+          .loneElement
+          .datums should contain theSameElementsInOrderAs expectedHistory
+      }
     }
 
     "annulling an annihilation" should "fuse the earlier lifecycle with a subsequent one" in {
@@ -802,49 +733,45 @@ trait Bugs
 
       val annihilationEvent = 1
 
-      worldResource
-        .use(world =>
-          IO {
-            world.revise(
-              0,
-              Change.forOneItem(Instant.ofEpochSecond(0L))(
-                itemId,
-                { item: IntegerHistory =>
-                  item.integerProperty = 1
-                }
-              ),
-              sharedAsOf
-            )
-
-            world.revise(
-              annihilationEvent,
-              Annihilation[IntegerHistory](Instant.ofEpochSecond(1L), itemId),
-              sharedAsOf
-            )
-
-            world.revise(
-              2,
-              Change.forOneItem(Instant.ofEpochSecond(2L))(
-                itemId,
-                { item: IntegerHistory =>
-                  item.integerProperty = 2
-                }
-              ),
-              sharedAsOf
-            )
-
-            world.annul(annihilationEvent, sharedAsOf)
-
-            val scope =
-              world.scopeFor(PositiveInfinity, world.nextRevision)
-
-            scope
-              .render(Bitemporal.withId[IntegerHistory](itemId))
-              .loneElement
-              .datums should contain theSameElementsInOrderAs expectedHistory
-          }
+      Using.resource(makeWorld()) { world =>
+        world.revise(
+          0,
+          Change.forOneItem(Instant.ofEpochSecond(0L))(
+            itemId,
+            { item: IntegerHistory =>
+              item.integerProperty = 1
+            }
+          ),
+          sharedAsOf
         )
-        .unsafeRunSync
+
+        world.revise(
+          annihilationEvent,
+          Annihilation[IntegerHistory](Instant.ofEpochSecond(1L), itemId),
+          sharedAsOf
+        )
+
+        world.revise(
+          2,
+          Change.forOneItem(Instant.ofEpochSecond(2L))(
+            itemId,
+            { item: IntegerHistory =>
+              item.integerProperty = 2
+            }
+          ),
+          sharedAsOf
+        )
+
+        world.annul(annihilationEvent, sharedAsOf)
+
+        val scope =
+          world.scopeFor(PositiveInfinity, world.nextRevision)
+
+        scope
+          .render(Bitemporal.withId[IntegerHistory](itemId))
+          .loneElement
+          .datums should contain theSameElementsInOrderAs expectedHistory
+      }
     }
 
     "booking in events in a mixed up order of physical time" should "work" in {
@@ -854,52 +781,48 @@ trait Bugs
 
       val expectedHistory = Seq(55, 66, 77)
 
-      worldResource
-        .use(world =>
-          IO {
-            world.revise(
-              0,
-              Change.forOneItem(Instant.ofEpochSecond(1L))(
-                itemId,
-                { item: IntegerHistory =>
-                  item.integerProperty = 66
-                }
-              ),
-              sharedAsOf
-            )
-
-            world.revise(
-              1,
-              Change.forOneItem(Instant.ofEpochSecond(2L))(
-                itemId,
-                { item: IntegerHistory =>
-                  item.integerProperty = 77
-                }
-              ),
-              sharedAsOf
-            )
-
-            world.revise(
-              2,
-              Change.forOneItem(Instant.ofEpochSecond(0L))(
-                itemId,
-                { item: IntegerHistory =>
-                  item.integerProperty = 55
-                }
-              ),
-              sharedAsOf
-            )
-
-            val scope =
-              world.scopeFor(PositiveInfinity, world.nextRevision)
-
-            scope
-              .render(Bitemporal.withId[IntegerHistory](itemId))
-              .loneElement
-              .datums should contain theSameElementsInOrderAs expectedHistory
-          }
+      Using.resource(makeWorld()) { world =>
+        world.revise(
+          0,
+          Change.forOneItem(Instant.ofEpochSecond(1L))(
+            itemId,
+            { item: IntegerHistory =>
+              item.integerProperty = 66
+            }
+          ),
+          sharedAsOf
         )
-        .unsafeRunSync
+
+        world.revise(
+          1,
+          Change.forOneItem(Instant.ofEpochSecond(2L))(
+            itemId,
+            { item: IntegerHistory =>
+              item.integerProperty = 77
+            }
+          ),
+          sharedAsOf
+        )
+
+        world.revise(
+          2,
+          Change.forOneItem(Instant.ofEpochSecond(0L))(
+            itemId,
+            { item: IntegerHistory =>
+              item.integerProperty = 55
+            }
+          ),
+          sharedAsOf
+        )
+
+        val scope =
+          world.scopeFor(PositiveInfinity, world.nextRevision)
+
+        scope
+          .render(Bitemporal.withId[IntegerHistory](itemId))
+          .loneElement
+          .datums should contain theSameElementsInOrderAs expectedHistory
+      }
     }
 
     "events that refer to items using inconsistent types" should "be rejected" in {
@@ -965,19 +888,15 @@ trait Bugs
           }
         )
 
-        worldResource
-          .use(world =>
-            IO {
-              intercept[RuntimeException] {
-                val permutedActions = random.shuffle(actions)
+        Using.resource(makeWorld()) { world =>
+          intercept[RuntimeException] {
+            val permutedActions = random.shuffle(actions)
 
-                for (action <- permutedActions) {
-                  action(world)
-                }
-              }
+            for (action <- permutedActions) {
+              action(world)
             }
-          )
-          .unsafeRunSync
+          }
+        }
       }
     }
 
@@ -990,65 +909,61 @@ trait Bugs
 
       val expectedHistory = Seq(11, 22, 33, 44, 55)
 
-      worldResource
-        .use(world =>
-          IO {
-            world.revise(
-              TreeMap(
-                10 -> Some(
-                  Change.forOneItem(Instant.ofEpochSecond(0L))(
-                    itemId,
-                    { item: IntegerHistory =>
-                      item.integerProperty = 11
-                    }
-                  )
-                ),
-                20 -> Some(
-                  Change.forOneItem(Instant.ofEpochSecond(1L))(
-                    itemId,
-                    { item: IntegerHistory =>
-                      item.integerProperty = 22
-                    }
-                  )
-                ),
-                30 -> Some(
-                  Change.forOneItem(sharedPhysicalTime)(
-                    itemId,
-                    { item: IntegerHistory =>
-                      item.integerProperty = 33
-                    }
-                  )
-                ),
-                40 -> Some(
-                  Change.forOneItem(sharedPhysicalTime)(
-                    itemId,
-                    { item: IntegerHistory =>
-                      item.integerProperty = 44
-                    }
-                  )
-                ),
-                50 -> Some(
-                  Change.forOneItem(Instant.ofEpochSecond(1000L))(
-                    itemId,
-                    { item: IntegerHistory =>
-                      item.integerProperty = 55
-                    }
-                  )
-                )
-              ),
-              sharedAsOf
+      Using.resource(makeWorld()) { world =>
+        world.revise(
+          TreeMap(
+            10 -> Some(
+              Change.forOneItem(Instant.ofEpochSecond(0L))(
+                itemId,
+                { item: IntegerHistory =>
+                  item.integerProperty = 11
+                }
+              )
+            ),
+            20 -> Some(
+              Change.forOneItem(Instant.ofEpochSecond(1L))(
+                itemId,
+                { item: IntegerHistory =>
+                  item.integerProperty = 22
+                }
+              )
+            ),
+            30 -> Some(
+              Change.forOneItem(sharedPhysicalTime)(
+                itemId,
+                { item: IntegerHistory =>
+                  item.integerProperty = 33
+                }
+              )
+            ),
+            40 -> Some(
+              Change.forOneItem(sharedPhysicalTime)(
+                itemId,
+                { item: IntegerHistory =>
+                  item.integerProperty = 44
+                }
+              )
+            ),
+            50 -> Some(
+              Change.forOneItem(Instant.ofEpochSecond(1000L))(
+                itemId,
+                { item: IntegerHistory =>
+                  item.integerProperty = 55
+                }
+              )
             )
-
-            val scope =
-              world.scopeFor(PositiveInfinity, world.nextRevision)
-
-            scope
-              .render(Bitemporal.withId[IntegerHistory](itemId))
-              .loneElement
-              .datums should contain theSameElementsInOrderAs expectedHistory
-          }
+          ),
+          sharedAsOf
         )
-        .unsafeRunSync
+
+        val scope =
+          world.scopeFor(PositiveInfinity, world.nextRevision)
+
+        scope
+          .render(Bitemporal.withId[IntegerHistory](itemId))
+          .loneElement
+          .datums should contain theSameElementsInOrderAs expectedHistory
+      }
     }
 
     "an annihilation without any following lifecycle" should "work" in {
@@ -1058,53 +973,47 @@ trait Bugs
 
       val sharedAsOf = Instant.ofEpochSecond(0)
 
-      val expectedHistory = Seq(11)
-
-      worldResource
-        .use(world =>
-          IO {
-            world.revise(
-              0,
-              Change.forOneItem(NegativeInfinity)(
-                itemId,
-                { item: MoreSpecificFooHistory =>
-                  item.property1 = ""
-                }
-              ),
-              sharedAsOf
-            )
-
-            world.revise(
-              TreeMap(
-                1 -> Some(
-                  Change.forOneItem(Instant.ofEpochSecond(-2L))(
-                    bystanderId,
-                    { item: BarHistory =>
-                      item.property1 = -5.8368005564593e89
-                    }
-                  )
-                ),
-                2 -> Some(
-                  Annihilation[BarHistory](
-                    Instant.ofEpochSecond(-1L),
-                    bystanderId
-                  )
-                ),
-                3 -> Some(
-                  Annihilation[FooHistory](Instant.ofEpochSecond(0L), itemId)
-                )
-              ),
-              sharedAsOf
-            )
-
-            val scope =
-              world.scopeFor(PositiveInfinity, world.nextRevision)
-
-            scope
-              .render(Bitemporal.withId[IntegerHistory](itemId)) shouldBe empty
-          }
+      Using.resource(makeWorld()) { world =>
+        world.revise(
+          0,
+          Change.forOneItem(NegativeInfinity)(
+            itemId,
+            { item: MoreSpecificFooHistory =>
+              item.property1 = ""
+            }
+          ),
+          sharedAsOf
         )
-        .unsafeRunSync
+
+        world.revise(
+          TreeMap(
+            1 -> Some(
+              Change.forOneItem(Instant.ofEpochSecond(-2L))(
+                bystanderId,
+                { item: BarHistory =>
+                  item.property1 = -5.8368005564593e89
+                }
+              )
+            ),
+            2 -> Some(
+              Annihilation[BarHistory](
+                Instant.ofEpochSecond(-1L),
+                bystanderId
+              )
+            ),
+            3 -> Some(
+              Annihilation[FooHistory](Instant.ofEpochSecond(0L), itemId)
+            )
+          ),
+          sharedAsOf
+        )
+
+        val scope =
+          world.scopeFor(PositiveInfinity, world.nextRevision)
+
+        scope
+          .render(Bitemporal.withId[IntegerHistory](itemId)) shouldBe empty
+      }
     }
 
     "annulling all events" should "yield a history with the same effects as prior to the annulments" in {
@@ -1113,8 +1022,6 @@ trait Bugs
       val bystanderId = "Name: 50"
 
       val sharedAsOf = Instant.ofEpochSecond(0)
-
-      val expectedHistory = Seq(11)
 
       val revisionActions = Array(
         (world: World) => {
@@ -1149,27 +1056,23 @@ trait Bugs
         }
       )
 
-      worldResource
-        .use(world =>
-          IO {
-            for (revisionAction <- revisionActions) {
-              revisionAction(world)
-            }
+      Using.resource(makeWorld()) { world =>
+        for (revisionAction <- revisionActions) {
+          revisionAction(world)
+        }
 
-            world.revise(TreeMap(0 until 3 map (_ -> None): _*), sharedAsOf)
+        world.revise(TreeMap(0 until 3 map (_ -> None): _*), sharedAsOf)
 
-            for (revisionAction <- revisionActions) {
-              revisionAction(world)
-            }
+        for (revisionAction <- revisionActions) {
+          revisionAction(world)
+        }
 
-            val scope =
-              world.scopeFor(PositiveInfinity, world.nextRevision)
+        val scope =
+          world.scopeFor(PositiveInfinity, world.nextRevision)
 
-            scope
-              .render(Bitemporal.withId[IntegerHistory](itemId)) shouldBe empty
-          }
-        )
-        .unsafeRunSync
+        scope
+          .render(Bitemporal.withId[IntegerHistory](itemId)) shouldBe empty
+      }
     }
 
     "annulling an event that shares an argument reference with another event to an item that is not directly referenced as a target" should "work" in {
@@ -1183,56 +1086,52 @@ trait Bugs
 
       val eventToBeAnnulled = 0
 
-      worldResource
-        .use(world =>
-          IO {
-            world.revise(
-              eventToBeAnnulled,
-              Change
-                .forTwoItems(Instant.ofEpochSecond(2L))(
-                  secondReferringId,
-                  referredId,
-                  {
-                    (
-                        item: ReferringHistory,
-                        fooHistory: MoreSpecificFooHistory
-                    ) =>
-                      item.referTo(fooHistory)
-                  }
-                ),
-              sharedAsOf
-            )
-
-            world.revise(
-              1,
-              Change
-                .forTwoItems(Instant.ofEpochSecond(0L))(
-                  firstReferringId,
-                  referredId,
-                  { (item: ReferringHistory, fooHistory: FooHistory) =>
-                    item.referTo(fooHistory)
-                  }
-                ),
-              sharedAsOf
-            )
-
-            world.annul(eventToBeAnnulled, sharedAsOf)
-
-            val scope =
-              world.scopeFor(PositiveInfinity, world.nextRevision)
-
-            scope
-              .render(
-                Bitemporal.withId[MoreSpecificFooHistory](referredId)
-              ) shouldBe empty
-
-            scope
-              .render(Bitemporal.withId[FooHistory](referredId))
-              .loneElement
-              .datums shouldBe empty
-          }
+      Using.resource(makeWorld()) { world =>
+        world.revise(
+          eventToBeAnnulled,
+          Change
+            .forTwoItems(Instant.ofEpochSecond(2L))(
+              secondReferringId,
+              referredId,
+              {
+                (
+                    item: ReferringHistory,
+                    fooHistory: MoreSpecificFooHistory
+                ) =>
+                  item.referTo(fooHistory)
+              }
+            ),
+          sharedAsOf
         )
-        .unsafeRunSync
+
+        world.revise(
+          1,
+          Change
+            .forTwoItems(Instant.ofEpochSecond(0L))(
+              firstReferringId,
+              referredId,
+              { (item: ReferringHistory, fooHistory: FooHistory) =>
+                item.referTo(fooHistory)
+              }
+            ),
+          sharedAsOf
+        )
+
+        world.annul(eventToBeAnnulled, sharedAsOf)
+
+        val scope =
+          world.scopeFor(PositiveInfinity, world.nextRevision)
+
+        scope
+          .render(
+            Bitemporal.withId[MoreSpecificFooHistory](referredId)
+          ) shouldBe empty
+
+        scope
+          .render(Bitemporal.withId[FooHistory](referredId))
+          .loneElement
+          .datums shouldBe empty
+      }
     }
 
     "correcting an event that breaks down into more than one patch" should "work" in {
@@ -1242,44 +1141,40 @@ trait Bugs
 
       val eventToBeCorrected = 0
 
-      worldResource
-        .use(world =>
-          IO {
-            world.revise(
-              eventToBeCorrected,
-              Change
-                .forOneItem(Instant.ofEpochSecond(0L))(
-                  referringId,
-                  { referrer: Thing =>
-                    referrer.property1 = 23
-                    referrer.property2 = "Hi"
-                  }
-                ),
-              sharedAsOf
-            )
-
-            world.revise(
-              eventToBeCorrected,
-              Change
-                .forOneItem(Instant.ofEpochSecond(0L))(
-                  referringId,
-                  { referrer: Thing =>
-                    referrer.property1 = 45
-                  }
-                ),
-              sharedAsOf
-            )
-
-            val scope =
-              world.scopeFor(PositiveInfinity, world.nextRevision)
-
-            scope
-              .render(Bitemporal.withId[Thing](referringId))
-              .loneElement
-              .property1 shouldBe 45
-          }
+      Using.resource(makeWorld()) { world =>
+        world.revise(
+          eventToBeCorrected,
+          Change
+            .forOneItem(Instant.ofEpochSecond(0L))(
+              referringId,
+              { referrer: Thing =>
+                referrer.property1 = 23
+                referrer.property2 = "Hi"
+              }
+            ),
+          sharedAsOf
         )
-        .unsafeRunSync
+
+        world.revise(
+          eventToBeCorrected,
+          Change
+            .forOneItem(Instant.ofEpochSecond(0L))(
+              referringId,
+              { referrer: Thing =>
+                referrer.property1 = 45
+              }
+            ),
+          sharedAsOf
+        )
+
+        val scope =
+          world.scopeFor(PositiveInfinity, world.nextRevision)
+
+        scope
+          .render(Bitemporal.withId[Thing](referringId))
+          .loneElement
+          .property1 shouldBe 45
+      }
     }
 
     "correcting events that relate a common pool of items to each other" should "work" in {
@@ -1301,47 +1196,43 @@ trait Bugs
       forAll(eventsGenerator, MinSuccessful(200)) { events =>
         val sharedAsOf = Instant.ofEpochSecond(0)
 
-        worldResource
-          .use(world =>
-            IO {
-              for (
-                (Booking(eventId, referrerId, referredId), step) <-
-                  events.zipWithIndex
-              ) {
-                world.revise(
-                  eventId,
-                  Change
-                    .forTwoItems(Instant.ofEpochSecond(0L))(
-                      referrerId,
-                      referredId,
-                      { (referrer: Thing, referred: Thing) =>
-                        referrer.property1 = step
-                        referrer
-                          .referTo(referred)
-                      }
-                    ),
-                  sharedAsOf
-                )
+        Using.resource(makeWorld()) { world =>
+          for (
+            (Booking(eventId, referrerId, referredId), step) <-
+              events.zipWithIndex
+          ) {
+            world.revise(
+              eventId,
+              Change
+                .forTwoItems(Instant.ofEpochSecond(0L))(
+                  referrerId,
+                  referredId,
+                  { (referrer: Thing, referred: Thing) =>
+                    referrer.property1 = step
+                    referrer
+                      .referTo(referred)
+                  }
+                ),
+              sharedAsOf
+            )
 
-                val scope =
-                  world
-                    .scopeFor(PositiveInfinity, world.nextRevision)
+            val scope =
+              world
+                .scopeFor(PositiveInfinity, world.nextRevision)
 
-                val Seq((referrer, referred)) = scope
-                  .render(
-                    (
-                      Bitemporal.withId[Thing](referrerId),
-                      Bitemporal
-                        .withId[Thing](referredId)
-                    ).mapN((_, _))
-                  )
+            val Seq((referrer, referred)) = scope
+              .render(
+                (
+                  Bitemporal.withId[Thing](referrerId),
+                  Bitemporal
+                    .withId[Thing](referredId)
+                ).mapN((_, _))
+              )
 
-                referrer.property1 shouldBe step
-                referrer.reference should contain(referred)
-              }
-            }
-          )
-          .unsafeRunSync
+            referrer.property1 shouldBe step
+            referrer.reference should contain(referred)
+          }
+        }
       }
     }
 
@@ -1370,57 +1261,53 @@ trait Bugs
 
       val sharedAsOf = Instant.ofEpochSecond(0)
 
-      worldResource
-        .use(world =>
-          IO {
-            for (
-              (Booking(eventId, referrerId, referredId), step) <-
-                events.zipWithIndex
-            ) {
-              world.revise(
-                eventId,
-                Change
-                  .forTwoItems(Instant.ofEpochSecond(0L))(
-                    referrerId,
-                    referredId,
-                    { (referrer: Thing, referred: Thing) =>
-                      referrer
-                        .referTo(referred)
-                      // NOTE: the following mutation really is necessary, it
-                      // can either come before
-                      // or after the call to 'referTo', but its position
-                      // affected which item became
-                      // a ghost when this test was failing.
-                      referrer.property1 = step
-                    }
-                  ),
-                sharedAsOf
-              )
-            }
+      Using.resource(makeWorld()) { world =>
+        for (
+          (Booking(eventId, referrerId, referredId), step) <-
+            events.zipWithIndex
+        ) {
+          world.revise(
+            eventId,
+            Change
+              .forTwoItems(Instant.ofEpochSecond(0L))(
+                referrerId,
+                referredId,
+                { (referrer: Thing, referred: Thing) =>
+                  referrer
+                    .referTo(referred)
+                  // NOTE: the following mutation really is necessary, it
+                  // can either come before
+                  // or after the call to 'referTo', but its position
+                  // affected which item became
+                  // a ghost when this test was failing.
+                  referrer.property1 = step
+                }
+              ),
+            sharedAsOf
+          )
+        }
 
-            val scope =
-              world.scopeFor(PositiveInfinity, world.nextRevision)
+        val scope =
+          world.scopeFor(PositiveInfinity, world.nextRevision)
 
-            val Seq(referrerTransitiveClosure) = scope
-              .render(Bitemporal.withId[Thing](headOfChainId))
-              .map(_.transitiveClosure)
+        val Seq(referrerTransitiveClosure) = scope
+          .render(Bitemporal.withId[Thing](headOfChainId))
+          .map(_.transitiveClosure)
 
-            referrerTransitiveClosure should contain theSameElementsAs Seq(
-              headOfChainId,
-              secondInChainId,
-              thirdInChainId,
-              endOfChainId
-            )
-
-            forAll(
-              scope
-                .render(Bitemporal.wildcard[Thing]())
-                .map(_.asInstanceOf[ItemExtensionApi])
-                .head
-            )(!_.isGhost)
-          }
+        referrerTransitiveClosure should contain theSameElementsAs Seq(
+          headOfChainId,
+          secondInChainId,
+          thirdInChainId,
+          endOfChainId
         )
-        .unsafeRunSync
+
+        forAll(
+          scope
+            .render(Bitemporal.wildcard[Thing]())
+            .map(_.asInstanceOf[ItemExtensionApi])
+            .head
+        )(!_.isGhost)
+      }
     }
   }
 }

--- a/src/test/scala/com/sageserpent/plutonium/ConnectionPoolResource.scala
+++ b/src/test/scala/com/sageserpent/plutonium/ConnectionPoolResource.scala
@@ -1,6 +1,5 @@
 package com.sageserpent.plutonium
 
-import cats.effect.{IO, Resource}
 import com.zaxxer.hikari.HikariDataSource
 import scalikejdbc._
 
@@ -8,78 +7,80 @@ import java.io.IOException
 import java.nio.file.attribute.BasicFileAttributes
 import java.nio.file.{FileVisitResult, FileVisitor, Files, Path}
 import java.util.UUID
+import scala.util.Using
 
 trait ConnectionPoolResource {
-  def connectionPoolResource: Resource[IO, ConnectionPool] =
-    for {
-      databaseDirectory <- Resource.make(IO {
-        Files.createTempDirectory("h2Storage")
-      })(cleanupDatabaseDirectory)
-      databaseName <- Resource.eval(IO { UUID.randomUUID().toString })
-      dataSource <- Resource.make(IO {
-        val result = new HikariDataSource()
-        result.setJdbcUrl(
-          s"jdbc:h2:file:${databaseDirectory.resolve(databaseName)};DB_CLOSE_ON_EXIT=FALSE;ANALYZE_AUTO=5000;ANALYZE_SAMPLE=50000"
-        )
-        result.setUsername("automatedTestIdentity")
-        result
-      })(dataSource => IO { dataSource.close() })
-      connectionPool <- Resource.make(IO {
-        new DataSourceConnectionPool(dataSource)
-      })(dropDatabaseTables)
-    } yield connectionPool
+  def createConnectionPool()(implicit manager: Using.Manager): ConnectionPool = {
+    val databaseDirectory =
+      manager(Files.createTempDirectory("h2Storage"))(
+        new Using.Releasable[Path] {
+          override def release(resource: Path): Unit =
+            cleanupDatabaseDirectory(resource)
+        }
+      )
+    val databaseName = UUID.randomUUID().toString
+    val dataSource = manager {
+      val result = new HikariDataSource()
+      result.setJdbcUrl(
+        s"jdbc:h2:file:${databaseDirectory.resolve(databaseName)};DB_CLOSE_ON_EXIT=FALSE;ANALYZE_AUTO=5000;ANALYZE_SAMPLE=50000"
+      )
+      result.setUsername("automatedTestIdentity")
+      result
+    }(new Using.Releasable[HikariDataSource] {
+      override def release(resource: HikariDataSource): Unit = resource.close()
+    })
+    manager(new DataSourceConnectionPool(dataSource))(
+      new Using.Releasable[DataSourceConnectionPool] {
+        override def release(resource: DataSourceConnectionPool): Unit =
+          dropDatabaseTables(resource)
+      }
+    )
+  }
 
   private def dropDatabaseTables(
       connectionPool: DataSourceConnectionPool
-  ): IO[Unit] = {
-    val dbResource: Resource[IO, DB] =
-      Resource.make(IO { DB(connectionPool.borrow()) })(db => IO { db.close() })
-    dbResource
-      .use(db =>
-        IO {
-          db localTx { implicit session: DBSession =>
-            sql"""
+  ): Unit = {
+    Using.resource(DB(connectionPool.borrow())) { db =>
+      db localTx { implicit session: DBSession =>
+        sql"""
              DROP ALL OBJECTS
          """.update.apply()
-          }
-        }
-      )
+      }
+    }
   }
 
-  private def cleanupDatabaseDirectory(directory: Path): IO[Unit] = {
-    IO {
-      Files.walkFileTree(
-        directory,
-        new FileVisitor[Path] {
-          override def preVisitDirectory(
-              dir: Path,
-              attrs: BasicFileAttributes
-          ): FileVisitResult =
-            FileVisitResult.CONTINUE
+  private def cleanupDatabaseDirectory(directory: Path): Unit = {
+    Files.walkFileTree(
+      directory,
+      new FileVisitor[Path] {
+        override def preVisitDirectory(
+            dir: Path,
+            attrs: BasicFileAttributes
+        ): FileVisitResult =
+          FileVisitResult.CONTINUE
 
-          override def visitFile(
-              file: Path,
-              attrs: BasicFileAttributes
-          ): FileVisitResult = {
-            Files.delete(file)
-            FileVisitResult.CONTINUE
-          }
-
-          override def visitFileFailed(
-              file: Path,
-              exc: IOException
-          ): FileVisitResult =
-            FileVisitResult.CONTINUE
-
-          override def postVisitDirectory(
-              dir: Path,
-              exc: IOException
-          ): FileVisitResult = {
-            Files.delete(dir)
-            FileVisitResult.CONTINUE
-          }
+        override def visitFile(
+            file: Path,
+            attrs: BasicFileAttributes
+        ): FileVisitResult = {
+          Files.delete(file)
+          FileVisitResult.CONTINUE
         }
-      )
-    }
+
+        override def visitFileFailed(
+            file: Path,
+            exc: IOException
+        ): FileVisitResult =
+          FileVisitResult.CONTINUE
+
+        override def postVisitDirectory(
+            dir: Path,
+            exc: IOException
+        ): FileVisitResult = {
+          Files.delete(dir)
+          FileVisitResult.CONTINUE
+        }
+      }
+    )
   }
 }

--- a/src/test/scala/com/sageserpent/plutonium/DirectoryResource.scala
+++ b/src/test/scala/com/sageserpent/plutonium/DirectoryResource.scala
@@ -3,43 +3,49 @@ package com.sageserpent.plutonium
 import java.io.IOException
 import java.nio.file.attribute.BasicFileAttributes
 import java.nio.file.{FileVisitResult, FileVisitor, Files, Path}
-
-import cats.effect.{IO, Resource}
+import scala.util.Using
 
 trait DirectoryResource {
-  def directoryResource(prefix: String): Resource[IO, Path] =
-    Resource.make(IO {
-      Files.createTempDirectory(prefix)
-    })(cleanupDatabaseDirectory)
+  def createTempDirectory(prefix: String)(implicit
+      manager: Using.Manager
+  ): Path =
+    manager(Files.createTempDirectory(prefix))(new Using.Releasable[Path] {
+      override def release(resource: Path): Unit =
+        cleanupDatabaseDirectory(resource)
+    })
 
-  private def cleanupDatabaseDirectory(directory: Path): IO[Unit] = {
-    IO {
-      Files.walkFileTree(
-        directory,
-        new FileVisitor[Path] {
-          override def preVisitDirectory(
-              dir: Path,
-              attrs: BasicFileAttributes): FileVisitResult =
-            FileVisitResult.CONTINUE
+  private def cleanupDatabaseDirectory(directory: Path): Unit = {
+    Files.walkFileTree(
+      directory,
+      new FileVisitor[Path] {
+        override def preVisitDirectory(
+            dir: Path,
+            attrs: BasicFileAttributes
+        ): FileVisitResult =
+          FileVisitResult.CONTINUE
 
-          override def visitFile(
-              file: Path,
-              attrs: BasicFileAttributes): FileVisitResult = {
-            Files.delete(file)
-            FileVisitResult.CONTINUE
-          }
-
-          override def visitFileFailed(file: Path,
-                                       exc: IOException): FileVisitResult =
-            FileVisitResult.CONTINUE
-
-          override def postVisitDirectory(dir: Path,
-                                          exc: IOException): FileVisitResult = {
-            Files.delete(dir)
-            FileVisitResult.CONTINUE
-          }
+        override def visitFile(
+            file: Path,
+            attrs: BasicFileAttributes
+        ): FileVisitResult = {
+          Files.delete(file)
+          FileVisitResult.CONTINUE
         }
-      )
-    }
+
+        override def visitFileFailed(
+            file: Path,
+            exc: IOException
+        ): FileVisitResult =
+          FileVisitResult.CONTINUE
+
+        override def postVisitDirectory(
+            dir: Path,
+            exc: IOException
+        ): FileVisitResult = {
+          Files.delete(dir)
+          FileVisitResult.CONTINUE
+        }
+      }
+    )
   }
 }

--- a/src/test/scala/com/sageserpent/plutonium/ExperimentalWorldBehaviours.scala
+++ b/src/test/scala/com/sageserpent/plutonium/ExperimentalWorldBehaviours.scala
@@ -1,7 +1,7 @@
 package com.sageserpent.plutonium
 
-import cats.effect.unsafe.implicits.global
-import cats.effect.{IO, Resource}
+
+import scala.util.Using
 import com.sageserpent.americium.utilities.randomEnrichment._
 import com.sageserpent.plutonium.utilities.{Finite, PositiveInfinity, Unbounded}
 import org.scalacheck.Prop.propBoolean
@@ -25,14 +25,14 @@ trait ExperimentalWorldBehaviours
         forkWhen: Unbounded[Instant],
         forkAsOf: Instant,
         seed: Long
-    ): Resource[IO, (Scope, World)] = {
+    )(implicit manager: Using.Manager): (Scope, World) = {
       val random = new Random(seed)
 
       if (random.nextBoolean()) {
         val scopeToDefineFork = baseWorld.scopeFor(forkWhen, forkAsOf)
-        Resource.make(IO {
+        scopeToDefineFork -> manager(
           baseWorld.forkExperimentalWorld(scopeToDefineFork)
-        })(world => IO { world.close() }) map (scopeToDefineFork -> _)
+        )
       } else {
         val scopeToDefineIntermediateFork = baseWorld.scopeFor(
           forkWhen match {
@@ -49,19 +49,18 @@ trait ExperimentalWorldBehaviours
           )
         )
 
-        for {
-          intermediateExperimentalWorld <- Resource.make(IO {
-            baseWorld.forkExperimentalWorld(scopeToDefineIntermediateFork)
-          })(world => IO { world.close() })
-          scopeToDefineFork = intermediateExperimentalWorld.scopeFor(
-            forkWhen,
-            forkAsOf
-          )
-          experimentalWorld <- Resource.make(IO {
-            intermediateExperimentalWorld
-              .forkExperimentalWorld(scopeToDefineFork)
-          })(world => IO { world.close() })
-        } yield scopeToDefineFork -> experimentalWorld
+        val intermediateExperimentalWorld = manager(
+          baseWorld.forkExperimentalWorld(scopeToDefineIntermediateFork)
+        )
+        val scopeToDefineFork = intermediateExperimentalWorld.scopeFor(
+          forkWhen,
+          forkAsOf
+        )
+        val experimentalWorld = manager(
+          intermediateExperimentalWorld
+            .forkExperimentalWorld(scopeToDefineFork)
+        )
+        scopeToDefineFork -> experimentalWorld
       }
     }
 
@@ -101,36 +100,34 @@ trait ExperimentalWorldBehaviours
               forkWhen,
               seed
             ) =>
-          (for {
-            baseWorld <- worldResource
-            _ <- Resource.eval(IO {
+          Using.resource(makeWorld()) { baseWorld =>
+            Using.Manager { manager =>
               recordEventsInWorld(
                 liftRecordings(bigShuffledHistoryOverLotsOfThings),
                 asOfs,
                 baseWorld
               )
-            })
-            scopeAndWorld <- scopeAndExperimentalWorldFor(
-              baseWorld,
-              forkWhen,
-              forkAsOf,
-              seed
-            )
-          } yield (baseWorld, scopeAndWorld._1, scopeAndWorld._2)).use {
-            case (baseWorld, scopeToDefineFork, experimentalWorld) =>
-              IO {
-                val filteredRevisionsFromBaseWorld =
-                  baseWorld.revisionAsOfs.takeWhile(revisionAsOf =>
-                    !forkAsOf.isBefore(revisionAsOf)
-                  )
 
-                val experimentalWorldRevisionAsOfsEvaluatedEarlyWhileRedisConnectionIsOpen =
-                  experimentalWorld.revisionAsOfs
+              val (scopeToDefineFork, experimentalWorld) =
+                scopeAndExperimentalWorldFor(
+                  baseWorld,
+                  forkWhen,
+                  forkAsOf,
+                  seed
+                )(manager)
 
-                (scopeToDefineFork.nextRevision == experimentalWorld.nextRevision) :| s"Expected 'experimentalWorld.nextRevision' to be: ${scopeToDefineFork.nextRevision}, but it was: ${experimentalWorld.nextRevision}." &&
-                (filteredRevisionsFromBaseWorld sameElements experimentalWorldRevisionAsOfsEvaluatedEarlyWhileRedisConnectionIsOpen) :| s"Expected 'experimentalWorld.revisionAsOfs' to be: '$filteredRevisionsFromBaseWorld', but they were: '${experimentalWorldRevisionAsOfsEvaluatedEarlyWhileRedisConnectionIsOpen}'."
-              }
-          }.unsafeRunSync
+              val filteredRevisionsFromBaseWorld =
+                baseWorld.revisionAsOfs.takeWhile(revisionAsOf =>
+                  !forkAsOf.isBefore(revisionAsOf)
+                )
+
+              val experimentalWorldRevisionAsOfsEvaluatedEarlyWhileRedisConnectionIsOpen =
+                experimentalWorld.revisionAsOfs
+
+              (scopeToDefineFork.nextRevision == experimentalWorld.nextRevision) :| s"Expected 'experimentalWorld.nextRevision' to be: ${scopeToDefineFork.nextRevision}, but it was: ${experimentalWorld.nextRevision}." &&
+              (filteredRevisionsFromBaseWorld sameElements experimentalWorldRevisionAsOfsEvaluatedEarlyWhileRedisConnectionIsOpen) :| s"Expected 'experimentalWorld.revisionAsOfs' to be: '$filteredRevisionsFromBaseWorld', but they were: '${experimentalWorldRevisionAsOfsEvaluatedEarlyWhileRedisConnectionIsOpen}'."
+            }.get
+          }
       })
     }
 
@@ -182,51 +179,48 @@ trait ExperimentalWorldBehaviours
               queryWhenNoLaterThanFork,
               seed
             ) =>
-          (for {
-            baseWorld <- worldResource
-            _ <- Resource.eval(IO {
+          Using.resource(makeWorld()) { baseWorld =>
+            Using.Manager { manager =>
               recordEventsInWorld(
                 liftRecordings(bigShuffledHistoryOverLotsOfThings),
                 asOfs,
                 baseWorld
               )
-            })
-            scopeAndWorld <- scopeAndExperimentalWorldFor(
-              baseWorld,
-              forkWhen,
-              forkAsOf,
-              seed
-            )
-          } yield (baseWorld, scopeAndWorld._2)).use {
-            case (baseWorld, experimentalWorld) =>
-              IO {
-                val scopeFromBaseWorld =
-                  baseWorld.scopeFor(
-                    queryWhenNoLaterThanFork,
-                    queryAsOfNoLaterThanFork
-                  )
-                val scopeFromExperimentalWorld =
-                  experimentalWorld.scopeFor(
-                    queryWhenNoLaterThanFork,
-                    queryAsOfNoLaterThanFork
-                  )
 
-                val baseWorldHistory =
-                  historyFrom(baseWorld, recordingsGroupedById)(
-                    scopeFromBaseWorld
-                  )
-                val experimentalWorldHistory =
-                  historyFrom(experimentalWorld, recordingsGroupedById)(
-                    scopeFromExperimentalWorld
-                  )
+              val (_, experimentalWorld) = scopeAndExperimentalWorldFor(
+                baseWorld,
+                forkWhen,
+                forkAsOf,
+                seed
+              )(manager)
 
-                ((baseWorldHistory.length == experimentalWorldHistory.length) :| s"${baseWorldHistory.length} == experimentalWorldHistory.length") && Prop
-                  .all(baseWorldHistory zip experimentalWorldHistory map {
-                    case (baseWorldCase, experimentalWorldCase) =>
-                      (baseWorldCase === experimentalWorldCase) :| s"${baseWorldCase} === experimentalWorldCase"
-                  }: _*)
-              }
-          }.unsafeRunSync
+              val scopeFromBaseWorld =
+                baseWorld.scopeFor(
+                  queryWhenNoLaterThanFork,
+                  queryAsOfNoLaterThanFork
+                )
+              val scopeFromExperimentalWorld =
+                experimentalWorld.scopeFor(
+                  queryWhenNoLaterThanFork,
+                  queryAsOfNoLaterThanFork
+                )
+
+              val baseWorldHistory =
+                historyFrom(baseWorld, recordingsGroupedById)(
+                  scopeFromBaseWorld
+                )
+              val experimentalWorldHistory =
+                historyFrom(experimentalWorld, recordingsGroupedById)(
+                  scopeFromExperimentalWorld
+                )
+
+              ((baseWorldHistory.length == experimentalWorldHistory.length) :| s"${baseWorldHistory.length} == experimentalWorldHistory.length") && Prop
+                .all(baseWorldHistory zip experimentalWorldHistory map {
+                  case (baseWorldCase, experimentalWorldCase) =>
+                    (baseWorldCase === experimentalWorldCase) :| s"${baseWorldCase} === experimentalWorldCase"
+                }: _*)
+            }.get
+          }
       })
     }
 
@@ -272,48 +266,45 @@ trait ExperimentalWorldBehaviours
               queryWhen,
               seed
             ) =>
-          (for {
-            baseWorld <- worldResource
-            _ <- Resource.eval(IO {
+          Using.resource(makeWorld()) { baseWorld =>
+            Using.Manager { manager =>
               recordEventsInWorld(
                 liftRecordings(bigShuffledHistoryOverLotsOfThings),
                 asOfs,
                 baseWorld
               )
-            })
-            scopeAndWorld <- scopeAndExperimentalWorldFor(
-              baseWorld,
-              PositiveInfinity,
-              forkAsOf,
-              seed
-            )
-          } yield (baseWorld, scopeAndWorld._2)).use {
-            case (baseWorld, experimentalWorld) =>
-              IO {
-                val scopeFromBaseWorld =
-                  baseWorld.scopeFor(queryWhen, queryAsOfNoLaterThanFork)
-                val scopeFromExperimentalWorld =
-                  experimentalWorld.scopeFor(
-                    queryWhen,
-                    queryAsOfNoLaterThanFork
-                  )
 
-                val baseWorldHistory =
-                  historyFrom(baseWorld, recordingsGroupedById)(
-                    scopeFromBaseWorld
-                  )
-                val experimentalWorldHistory =
-                  historyFrom(experimentalWorld, recordingsGroupedById)(
-                    scopeFromExperimentalWorld
-                  )
+              val (_, experimentalWorld) = scopeAndExperimentalWorldFor(
+                baseWorld,
+                PositiveInfinity,
+                forkAsOf,
+                seed
+              )(manager)
 
-                ((baseWorldHistory.length == experimentalWorldHistory.length) :| s"${baseWorldHistory.length} == experimentalWorldHistory.length") && Prop
-                  .all(baseWorldHistory zip experimentalWorldHistory map {
-                    case (baseWorldCase, experimentalWorldCase) =>
-                      (baseWorldCase === experimentalWorldCase) :| s"${baseWorldCase} === experimentalWorldCase"
-                  }: _*)
-              }
-          }.unsafeRunSync
+              val scopeFromBaseWorld =
+                baseWorld.scopeFor(queryWhen, queryAsOfNoLaterThanFork)
+              val scopeFromExperimentalWorld =
+                experimentalWorld.scopeFor(
+                  queryWhen,
+                  queryAsOfNoLaterThanFork
+                )
+
+              val baseWorldHistory =
+                historyFrom(baseWorld, recordingsGroupedById)(
+                  scopeFromBaseWorld
+                )
+              val experimentalWorldHistory =
+                historyFrom(experimentalWorld, recordingsGroupedById)(
+                  scopeFromExperimentalWorld
+                )
+
+              ((baseWorldHistory.length == experimentalWorldHistory.length) :| s"${baseWorldHistory.length} == experimentalWorldHistory.length") && Prop
+                .all(baseWorldHistory zip experimentalWorldHistory map {
+                  case (baseWorldCase, experimentalWorldCase) =>
+                    (baseWorldCase === experimentalWorldCase) :| s"${baseWorldCase} === experimentalWorldCase"
+                }: _*)
+            }.get
+          }
       })
     }
 
@@ -391,62 +382,59 @@ trait ExperimentalWorldBehaviours
               queryWhen,
               seed
             ) =>
-          (for {
-            baseWorld <- worldResource
-            _ <- Resource.eval(IO {
+          Using.resource(makeWorld()) { baseWorld =>
+            Using.Manager { manager =>
               recordEventsInWorld(
                 liftRecordings(bigShuffledHistoryOverLotsOfThings),
                 baseAsOfs,
                 baseWorld
               )
-            })
-            scopeAndWorld <- scopeAndExperimentalWorldFor(
-              baseWorld,
-              forkWhen,
-              forkAsOf,
-              seed
-            )
-          } yield (baseWorld, scopeAndWorld._2)).use {
-            case (baseWorld, experimentalWorld) =>
-              IO {
-                val scopeFromExperimentalWorld =
-                  experimentalWorld.scopeFor(queryWhen, queryAsOf)
 
-                val experimentalWorldHistory =
-                  historyFrom(experimentalWorld, recordingsGroupedById)(
-                    scopeFromExperimentalWorld
-                  )
+              val (_, experimentalWorld) = scopeAndExperimentalWorldFor(
+                baseWorld,
+                forkWhen,
+                forkAsOf,
+                seed
+              )(manager)
 
-                // There is a subtlety here - the first of the following asOfs
-                // may line up with the last or the original asOfs
-                // - however the experimental world should still remain
-                // unperturbed.
-                recordEventsInWorld(annulmentsGalore, annulmentAsOfs, baseWorld)
+              val scopeFromExperimentalWorld =
+                experimentalWorld.scopeFor(queryWhen, queryAsOf)
 
-                recordEventsInWorld(
-                  liftRecordings(bigFollowingShuffledHistoryOverLotsOfThings),
-                  rewritingAsOfs,
-                  baseWorld
+              val experimentalWorldHistory =
+                historyFrom(experimentalWorld, recordingsGroupedById)(
+                  scopeFromExperimentalWorld
                 )
 
-                val scopeFromExperimentalWorldAfterBaseWorldRevised =
-                  experimentalWorld.scopeFor(queryWhen, queryAsOf)
+              // There is a subtlety here - the first of the following asOfs
+              // may line up with the last or the original asOfs
+              // - however the experimental world should still remain
+              // unperturbed.
+              recordEventsInWorld(annulmentsGalore, annulmentAsOfs, baseWorld)
 
-                val experimentalWorldHistoryAfterBaseWorldRevised =
-                  historyFrom(experimentalWorld, recordingsGroupedById)(
-                    scopeFromExperimentalWorldAfterBaseWorldRevised
-                  )
+              recordEventsInWorld(
+                liftRecordings(bigFollowingShuffledHistoryOverLotsOfThings),
+                rewritingAsOfs,
+                baseWorld
+              )
 
-                ((experimentalWorldHistory.length == experimentalWorldHistoryAfterBaseWorldRevised.length) :| s"${experimentalWorldHistory.length} == experimentalWorldHistoryAfterBaseWorldRevised.length") && Prop
-                  .all(experimentalWorldHistory zip experimentalWorldHistoryAfterBaseWorldRevised map {
-                    case (
-                          experimentalWorldCase,
-                          experimentalWorldCaseAfterBaseWorldRevised
-                        ) =>
-                      (experimentalWorldCase === experimentalWorldCaseAfterBaseWorldRevised) :| s"${experimentalWorldCase} === experimentalWorldCaseAfterBaseWorldRevised"
-                  }: _*)
-              }
-          }.unsafeRunSync
+              val scopeFromExperimentalWorldAfterBaseWorldRevised =
+                experimentalWorld.scopeFor(queryWhen, queryAsOf)
+
+              val experimentalWorldHistoryAfterBaseWorldRevised =
+                historyFrom(experimentalWorld, recordingsGroupedById)(
+                  scopeFromExperimentalWorldAfterBaseWorldRevised
+                )
+
+              ((experimentalWorldHistory.length == experimentalWorldHistoryAfterBaseWorldRevised.length) :| s"${experimentalWorldHistory.length} == experimentalWorldHistoryAfterBaseWorldRevised.length") && Prop
+                .all(experimentalWorldHistory zip experimentalWorldHistoryAfterBaseWorldRevised map {
+                  case (
+                        experimentalWorldCase,
+                        experimentalWorldCaseAfterBaseWorldRevised
+                      ) =>
+                    (experimentalWorldCase === experimentalWorldCaseAfterBaseWorldRevised) :| s"${experimentalWorldCase} === experimentalWorldCaseAfterBaseWorldRevised"
+                }: _*)
+            }.get
+          }
       })
     }
 
@@ -498,23 +486,21 @@ trait ExperimentalWorldBehaviours
               queryWhenAfterFork,
               seed
             ) =>
-          (for {
-            baseWorld <- worldResource
-            _ <- Resource.eval(IO {
+          Using.resource(makeWorld()) { baseWorld =>
+            Using.Manager { manager =>
               recordEventsInWorld(
                 liftRecordings(bigShuffledHistoryOverLotsOfThings),
                 asOfs,
                 baseWorld
               )
-            })
-            scopeAndWorld <- scopeAndExperimentalWorldFor(
-              baseWorld,
-              forkWhen,
-              forkAsOf,
-              seed
-            )
-          } yield scopeAndWorld._2).use { case experimentalWorld =>
-            IO {
+
+              val (_, experimentalWorld) = scopeAndExperimentalWorldFor(
+                baseWorld,
+                forkWhen,
+                forkAsOf,
+                seed
+              )(manager)
+
               val scopeFromExperimentalWorld =
                 experimentalWorld.scopeFor(forkWhen, queryAsOfNoLaterThanFork)
 
@@ -542,8 +528,8 @@ trait ExperimentalWorldBehaviours
                       ) =>
                     (experimentalWorldCase === experimentalWorldCaseAfterBaseWorldRevised) :| s"${experimentalWorldCase} === experimentalWorldCaseAfterBaseWorldRevised"
                 }: _*)
-            }
-          }.unsafeRunSync
+            }.get
+          }
       })
     }
 
@@ -618,23 +604,21 @@ trait ExperimentalWorldBehaviours
               queryWhen,
               seed
             ) =>
-          (for {
-            baseWorld <- worldResource
-            _ <- Resource.eval(IO {
+          Using.resource(makeWorld()) { baseWorld =>
+            Using.Manager { manager =>
               recordEventsInWorld(
                 liftRecordings(bigShuffledHistoryOverLotsOfThings),
                 baseAsOfs,
                 baseWorld
               )
-            })
-            scopeAndWorld <- scopeAndExperimentalWorldFor(
-              baseWorld,
-              forkWhen,
-              forkAsOf,
-              seed
-            )
-          } yield scopeAndWorld._2).use { experimentalWorld =>
-            IO {
+
+              val (_, experimentalWorld) = scopeAndExperimentalWorldFor(
+                baseWorld,
+                forkWhen,
+                forkAsOf,
+                seed
+              )(manager)
+
               recordEventsInWorld(
                 annulmentsGalore,
                 annulmentAsOfs,
@@ -677,8 +661,8 @@ trait ExperimentalWorldBehaviours
                     )
                 }: _*)
               } else Prop.undecided
-            }
-          }.unsafeRunSync
+            }.get
+          }
       })
     }
 
@@ -735,64 +719,61 @@ trait ExperimentalWorldBehaviours
               queryWhen,
               seed
             ) =>
-          (for {
-            baseWorld <- worldResource
-            _ <- Resource.eval(IO {
+          Using.resource(makeWorld()) { baseWorld =>
+            Using.Manager { manager =>
               recordEventsInWorld(
                 liftRecordings(bigShuffledHistoryOverLotsOfThings),
                 baseAsOfs,
                 baseWorld
               )
-            })
-            scopeAndWorld <- scopeAndExperimentalWorldFor(
-              baseWorld,
-              forkWhen,
-              forkAsOf,
-              seed
-            )
-          } yield (baseWorld, scopeAndWorld._2)).use {
-            case (baseWorld, experimentalWorld) =>
-              IO {
-                recordEventsInWorld(
-                  annulmentsGalore,
-                  followingAsOfs,
-                  experimentalWorld
-                )
 
-                val scopeFromBaseWorld =
-                  baseWorld.scopeFor(queryWhen, baseWorld.nextRevision)
+              val (_, experimentalWorld) = scopeAndExperimentalWorldFor(
+                baseWorld,
+                forkWhen,
+                forkAsOf,
+                seed
+              )(manager)
 
-                val checks = for {
-                  RecordingsNoLaterThan(
-                    historyId,
-                    historiesFrom,
-                    pertinentRecordings,
-                    _,
-                    _
-                  ) <- recordingsGroupedById flatMap (_.thePartNoLaterThan(
+              recordEventsInWorld(
+                annulmentsGalore,
+                followingAsOfs,
+                experimentalWorld
+              )
+
+              val scopeFromBaseWorld =
+                baseWorld.scopeFor(queryWhen, baseWorld.nextRevision)
+
+              val checks = for {
+                RecordingsNoLaterThan(
+                  historyId,
+                  historiesFrom,
+                  pertinentRecordings,
+                  _,
+                  _
+                ) <- recordingsGroupedById flatMap (_.thePartNoLaterThan(
                     queryWhen
                   ))
-                  Seq(history) = historiesFrom(scopeFromBaseWorld)
-                } yield (
-                  historyId,
-                  history.datums,
-                  pertinentRecordings.map(_._1)
-                )
+                Seq(history) = historiesFrom(scopeFromBaseWorld)
+              } yield (
+                historyId,
+                history.datums,
+                pertinentRecordings.map(_._1)
+              )
 
-                if (checks.nonEmpty) {
-                  Prop.all(checks.map {
-                    case (historyId, actualHistory, expectedHistory) =>
-                      ((actualHistory.length == expectedHistory.length) :| s"For ${historyId}, ${actualHistory.length} == expectedHistory.length") &&
-                      Prop.all(
-                        (actualHistory zip expectedHistory zipWithIndex) map {
-                          case ((actual, expected), step) =>
-                            (actual == expected) :| s"For ${historyId}, @step ${step}, ${actual} == ${expected}"
-                        } toSeq: _*
-                      )
-                  }: _*)
-                } else Prop.undecided
-              }
-          }.unsafeRunSync
+              if (checks.nonEmpty) {
+                Prop.all(checks.map {
+                  case (historyId, actualHistory, expectedHistory) =>
+                    ((actualHistory.length == expectedHistory.length) :| s"For ${historyId}, ${actualHistory.length} == expectedHistory.length") &&
+                    Prop.all(
+                      (actualHistory zip expectedHistory zipWithIndex) map {
+                        case ((actual, expected), step) =>
+                          (actual == expected) :| s"For ${historyId}, @step ${step}, ${actual} == ${expected}"
+                      } toSeq: _*
+                    )
+                }: _*)
+              } else Prop.undecided
+            }.get
+          }
       })
     }
   }

--- a/src/test/scala/com/sageserpent/plutonium/WorldBehaviours.scala
+++ b/src/test/scala/com/sageserpent/plutonium/WorldBehaviours.scala
@@ -1,8 +1,7 @@
 package com.sageserpent.plutonium
 
-import cats.effect.IO
-import cats.effect.unsafe.implicits.global
 import cats.syntax.apply._
+import scala.util.Using
 import com.sageserpent.americium
 
 import java.time.Instant
@@ -44,9 +43,7 @@ trait WorldBehaviours
 
   def worldWithNoHistoryBehaviour = {
     it should "not contain any identifiables" in {
-      worldResource
-        .use(world =>
-          IO {
+      Using.resource(makeWorld()) { world =>
             val scopeGenerator = for {
               when <- unboundedInstantGenerator
               asOf <- instantGenerator
@@ -59,19 +56,13 @@ trait WorldBehaviours
               scope.render(exampleBitemporal).isEmpty
             }))
           }
-        )
-        .unsafeRunSync
     }
 
     it should "have no current revision" in {
       check(
-        worldResource
-          .use(world =>
-            IO {
+        Using.resource(makeWorld()) { world =>
               (World.initialRevision == world.nextRevision) :| s"Initial revision of a world ${world.nextRevision} should be: ${World.initialRevision}."
             }
-          )
-          .unsafeRunSync
       )
     }
   }
@@ -142,9 +133,7 @@ trait WorldBehaviours
               asOfToLatestEventWhenMap,
               asOfsIncludingAllEventsNoLaterThanTheQueryWhen
             ) =>
-          worldResource
-            .use(world =>
-              IO {
+          Using.resource(makeWorld()) { world =>
                 recordEventsInWorld(
                   liftRecordings(
                     bigHistoryOverLotsOfThingsSortedInEventWhenOrder
@@ -193,8 +182,6 @@ trait WorldBehaviours
                   }: _*)
                 else Prop.undecided
               }
-            )
-            .unsafeRunSync
       })
     }
   }
@@ -238,9 +225,7 @@ trait WorldBehaviours
                 asOfs,
                 queryWhen
               ) =>
-            worldResource
-              .use(world =>
-                IO {
+            Using.resource(makeWorld()) { world =>
                   recordEventsInWorld(
                     liftRecordings(bigShuffledHistoryOverLotsOfThings),
                     asOfs,
@@ -268,8 +253,6 @@ trait WorldBehaviours
                     }: _*)
                   else Prop.undecided
                 }
-              )
-              .unsafeRunSync
         }
       )
     }
@@ -291,9 +274,7 @@ trait WorldBehaviours
       check(Prop.forAllNoShrink(testCaseGenerator) {
         case (random, fooHistoryIds, referringHistoryIds) =>
           val sharedAsOf = Instant.ofEpochSecond(0L)
-          worldResource
-            .use(world =>
-              IO {
+          Using.resource(makeWorld()) { world =>
                 val linearizationIndices =
                   fooHistoryIds zip LazyList.continually {
                     random.nextInt(3)
@@ -366,8 +347,6 @@ trait WorldBehaviours
                   (bitemporalWithExpectedFlavourOfHistory.id == fooHistoryId) :| s"Expected to have a single bitemporal of id: $fooHistoryId, but got one of id: ${bitemporalWithExpectedFlavourOfHistory.id}"
                 }: _*)
               }
-            )
-            .unsafeRunSync
       })
     }
 
@@ -406,9 +385,7 @@ trait WorldBehaviours
               queryWhen,
               random
             ) =>
-          worldResource
-            .use(world =>
-              IO {
+          Using.resource(makeWorld()) { world =>
                 val revisions = recordEventsInWorld(
                   liftRecordings(bigShuffledHistoryOverLotsOfThings),
                   asOfs,
@@ -503,8 +480,6 @@ trait WorldBehaviours
                   }: _*)
                 else Prop.undecided
               }
-            )
-            .unsafeRunSync
       })
     }
 
@@ -543,9 +518,7 @@ trait WorldBehaviours
               queryWhen,
               random
             ) =>
-          worldResource
-            .use(world =>
-              IO {
+          Using.resource(makeWorld()) { world =>
                 val revisions = recordEventsInWorld(
                   liftRecordings(bigShuffledHistoryOverLotsOfThings),
                   asOfs,
@@ -631,8 +604,6 @@ trait WorldBehaviours
                   }: _*)
                 else Prop.undecided
               }
-            )
-            .unsafeRunSync
       })
     }
 
@@ -659,9 +630,7 @@ trait WorldBehaviours
       } yield (bigShuffledHistoryOverLotsOfThings, asOfs, queryWhen, random)
       check(Prop.forAllNoShrink(testCaseGenerator) {
         case (bigShuffledHistoryOverLotsOfThings, asOfs, queryWhen, random) =>
-          worldResource
-            .use(world =>
-              IO {
+          Using.resource(makeWorld()) { world =>
                 val revisions = recordEventsInWorld(
                   liftRecordings(bigShuffledHistoryOverLotsOfThings),
                   asOfs,
@@ -743,8 +712,6 @@ trait WorldBehaviours
                   }: _*)
                 else Prop.undecided
               }
-            )
-            .unsafeRunSync
       })
     }
 
@@ -779,9 +746,7 @@ trait WorldBehaviours
               asOfs,
               queryWhen
             ) =>
-          worldResource
-            .use(world =>
-              IO {
+          Using.resource(makeWorld()) { world =>
                 (try {
                   recordEventsInWorld(
                     liftRecordings(bigShuffledFaultyHistoryOverLotsOfThings),
@@ -794,8 +759,6 @@ trait WorldBehaviours
                     Prop.proved
                 }) :| "An exception should have been thrown when making an inconsistent revision."
               }
-            )
-            .unsafeRunSync
       })
     }
 
@@ -832,9 +795,7 @@ trait WorldBehaviours
               asOfs,
               queryWhen
             ) =>
-          worldResource
-            .use(world =>
-              IO {
+          Using.resource(makeWorld()) { world =>
                 recordEventsInWorld(
                   liftRecordings(bigShuffledHistoryOverLotsOfThings),
                   asOfs,
@@ -873,8 +834,6 @@ trait WorldBehaviours
                   }: _*)
                 else Prop.undecided
               }
-            )
-            .unsafeRunSync
       })
     }
 
@@ -912,9 +871,7 @@ trait WorldBehaviours
       } yield (bigShuffledHistoryOverLotsOfThings, asOfs, queryWhen, sequence)
       check(Prop.forAllNoShrink(testCaseGenerator) {
         case (bigShuffledHistoryOverLotsOfThings, asOfs, queryWhen, sequence) =>
-          worldResource
-            .use(world =>
-              IO {
+          Using.resource(makeWorld()) { world =>
                 recordEventsInWorld(
                   liftRecordings(bigShuffledHistoryOverLotsOfThings),
                   asOfs,
@@ -932,8 +889,6 @@ trait WorldBehaviours
 
                 Prop.proved
               }
-            )
-            .unsafeRunSync
       })
     }
 
@@ -970,9 +925,7 @@ trait WorldBehaviours
               asOfs,
               queryWhen
             ) =>
-          worldResource
-            .use(world =>
-              IO {
+          Using.resource(makeWorld()) { world =>
                 recordEventsInWorld(
                   liftRecordings(bigShuffledHistoryOverLotsOfThings),
                   asOfs,
@@ -998,8 +951,6 @@ trait WorldBehaviours
                   }: _*)
                 else Prop.undecided
               }
-            )
-            .unsafeRunSync
       })
     }
 
@@ -1036,9 +987,7 @@ trait WorldBehaviours
               asOfs,
               queryWhen
             ) =>
-          worldResource
-            .use(world =>
-              IO {
+          Using.resource(makeWorld()) { world =>
                 recordEventsInWorld(
                   liftRecordings(bigShuffledHistoryOverLotsOfThings),
                   asOfs,
@@ -1081,8 +1030,6 @@ trait WorldBehaviours
                   }: _*)
                 else Prop.undecided
               }
-            )
-            .unsafeRunSync
       })
     }
 
@@ -1125,9 +1072,7 @@ trait WorldBehaviours
                 asOfs,
                 queryWhen
               ) =>
-            worldResource
-              .use(world =>
-                IO {
+            Using.resource(makeWorld()) { world =>
                   recordEventsInWorld(
                     liftRecordings(bigShuffledHistoryOverLotsOfThings),
                     asOfs,
@@ -1188,8 +1133,6 @@ trait WorldBehaviours
                     }: _*)
                   else Prop.undecided
                 }
-              )
-              .unsafeRunSync
         },
         minSuccessful(200),
         sizeRange(5)
@@ -1235,9 +1178,7 @@ trait WorldBehaviours
                 asOfs,
                 queryWhen
               ) =>
-            worldResource
-              .use(world =>
-                IO {
+            Using.resource(makeWorld()) { world =>
                   recordEventsInWorld(
                     liftRecordings(bigShuffledHistoryOverLotsOfThings),
                     asOfs,
@@ -1303,8 +1244,6 @@ trait WorldBehaviours
                     }: _*)
                   else Prop.undecided
                 }
-              )
-              .unsafeRunSync
         },
         minSuccessful(12),
         sizeRange(5)
@@ -1344,9 +1283,7 @@ trait WorldBehaviours
               asOfs,
               queryWhen
             ) =>
-          worldResource
-            .use(world =>
-              IO {
+          Using.resource(makeWorld()) { world =>
                 recordEventsInWorld(
                   liftRecordings(bigShuffledHistoryOverLotsOfThings),
                   asOfs,
@@ -1367,8 +1304,6 @@ trait WorldBehaviours
                   }: _*)
                 else Prop.undecided
               }
-            )
-            .unsafeRunSync
       })
     }
 
@@ -1407,9 +1342,7 @@ trait WorldBehaviours
                   asOfs,
                   queryWhen
                 ) =>
-              worldResource
-                .use(world =>
-                  IO {
+              Using.resource(makeWorld()) { world =>
                     recordEventsInWorld(
                       liftRecordings(bigShuffledHistoryOverLotsOfThings),
                       asOfs,
@@ -1455,8 +1388,6 @@ trait WorldBehaviours
                       }: _*)
                     else Prop.undecided
                   }
-                )
-                .unsafeRunSync
           }
       )
     }
@@ -1500,9 +1431,7 @@ trait WorldBehaviours
                 asOfs,
                 queryWhen
               ) =>
-            worldResource
-              .use(world =>
-                IO {
+            Using.resource(makeWorld()) { world =>
                   recordEventsInWorld(
                     liftRecordings(bigShuffledHistoryOverLotsOfThings),
                     asOfs,
@@ -1545,8 +1474,6 @@ trait WorldBehaviours
                     }: _*)
                   else Prop.undecided
                 }
-              )
-              .unsafeRunSync
         },
         maxDiscardedFactor(10),
         minSuccessful(12),
@@ -1588,9 +1515,7 @@ trait WorldBehaviours
               asOfs,
               referencingEventWhen
             ) =>
-          worldResource
-            .use(world =>
-              IO {
+          Using.resource(makeWorld()) { world =>
                 recordEventsInWorld(
                   liftRecordings(bigShuffledHistoryOverLotsOfThings),
                   asOfs,
@@ -1672,8 +1597,6 @@ trait WorldBehaviours
                   }: _*)
                 else Prop.undecided
               }
-            )
-            .unsafeRunSync
       })
     }
 
@@ -1711,9 +1634,7 @@ trait WorldBehaviours
               asOfs,
               referencingEventWhen
             ) =>
-          worldResource
-            .use(world =>
-              IO {
+          Using.resource(makeWorld()) { world =>
                 recordEventsInWorld(
                   liftRecordings(bigShuffledHistoryOverLotsOfThings),
                   asOfs,
@@ -1826,8 +1747,6 @@ trait WorldBehaviours
                   }: _*)
                 else Prop.undecided
               }
-            )
-            .unsafeRunSync
       })
     }
 
@@ -1862,9 +1781,7 @@ trait WorldBehaviours
               asOfs,
               definiteQueryWhen
             ) =>
-          worldResource
-            .use(world =>
-              IO {
+          Using.resource(makeWorld()) { world =>
                 recordEventsInWorld(
                   liftRecordings(bigShuffledHistoryOverLotsOfThings),
                   asOfs,
@@ -1897,8 +1814,6 @@ trait WorldBehaviours
                   } :| s"Should have rejected the attempt to annihilate an item that didn't exist at the query time."): _*
                 )
               }
-            )
-            .unsafeRunSync
       })
     }
 
@@ -1924,9 +1839,7 @@ trait WorldBehaviours
       } yield (bigShuffledHistoryOverLotsOfThings, asOfs)
       check(Prop.forAllNoShrink(testCaseGenerator) {
         case (bigShuffledHistoryOverLotsOfThings, asOfs) =>
-          worldResource
-            .use(world =>
-              IO {
+          Using.resource(makeWorld()) { world =>
                 val revisions = recordEventsInWorld(
                   liftRecordings(bigShuffledHistoryOverLotsOfThings),
                   asOfs,
@@ -1935,8 +1848,6 @@ trait WorldBehaviours
 
                 (1 + revisions.last === world.nextRevision) :| s"1 + ${revisions}.last === ${world.nextRevision}"
               }
-            )
-            .unsafeRunSync
       })
     }
 
@@ -1962,9 +1873,7 @@ trait WorldBehaviours
       } yield (bigShuffledHistoryOverLotsOfThings, asOfs)
       check(Prop.forAllNoShrink(testCaseGenerator) {
         case (bigShuffledHistoryOverLotsOfThings, asOfs) =>
-          worldResource
-            .use(world =>
-              IO {
+          Using.resource(makeWorld()) { world =>
                 recordEventsInWorld(
                   liftRecordings(bigShuffledHistoryOverLotsOfThings),
                   asOfs,
@@ -1976,8 +1885,6 @@ trait WorldBehaviours
                     (asOf === timelineAsOf) :| s"${asOf} === ${timelineAsOf}"
                 }: _*)
               }
-            )
-            .unsafeRunSync
       })
     }
 
@@ -2003,9 +1910,7 @@ trait WorldBehaviours
       } yield (bigShuffledHistoryOverLotsOfThings, asOfs)
       check(Prop.forAllNoShrink(testCaseGenerator) {
         case (bigShuffledHistoryOverLotsOfThings, asOfs) =>
-          worldResource
-            .use(world =>
-              IO {
+          Using.resource(makeWorld()) { world =>
                 recordEventsInWorld(
                   liftRecordings(bigShuffledHistoryOverLotsOfThings),
                   asOfs,
@@ -2017,8 +1922,6 @@ trait WorldBehaviours
                     !first.isAfter(second) :| s"!${first}.isAfter(${second})"
                 }: _*)
               }
-            )
-            .unsafeRunSync
       })
     }
 
@@ -2044,9 +1947,7 @@ trait WorldBehaviours
       } yield (bigShuffledHistoryOverLotsOfThings, asOfs)
       check(Prop.forAllNoShrink(testCaseGenerator) {
         case (bigShuffledHistoryOverLotsOfThings, asOfs) =>
-          worldResource
-            .use(world =>
-              IO {
+          Using.resource(makeWorld()) { world =>
                 val revisions = recordEventsInWorld(
                   liftRecordings(bigShuffledHistoryOverLotsOfThings),
                   asOfs,
@@ -2058,8 +1959,6 @@ trait WorldBehaviours
                     (index === revision) :| s"${index} === ${revision}"
                 }: _*)
               }
-            )
-            .unsafeRunSync
       })
     }
 
@@ -2085,9 +1984,7 @@ trait WorldBehaviours
       } yield (bigShuffledHistoryOverLotsOfThings, asOfs)
       check(Prop.forAllNoShrink(testCaseGenerator) {
         case (bigShuffledHistoryOverLotsOfThings, asOfs) =>
-          worldResource
-            .use(world =>
-              IO {
+          Using.resource(makeWorld()) { world =>
                 recordEventsInWorld(
                   liftRecordings(bigShuffledHistoryOverLotsOfThings),
                   asOfs,
@@ -2096,8 +1993,6 @@ trait WorldBehaviours
 
                 (world.nextRevision === world.revisionAsOfs.length) :| s"${world.nextRevision} === ${world.revisionAsOfs}.length"
               }
-            )
-            .unsafeRunSync
       })
     }
 
@@ -2123,9 +2018,7 @@ trait WorldBehaviours
       } yield (bigShuffledHistoryOverLotsOfThings, asOfs, random)
       check(Prop.forAllNoShrink(testCaseGenerator) {
         case (bigShuffledHistoryOverLotsOfThings, asOfs, random) =>
-          worldResource
-            .use(world =>
-              IO {
+          Using.resource(makeWorld()) { world =>
                 val numberOfRevisions = asOfs.length
 
                 val candidateIndicesToStartATranspose =
@@ -2159,8 +2052,6 @@ trait WorldBehaviours
                   Prop.proved
                 } :| s"Using ${asOfsWithIncorrectTransposition} should cause a precondition failure."
               }
-            )
-            .unsafeRunSync
       })
     }
 
@@ -2187,9 +2078,7 @@ trait WorldBehaviours
       } yield (bigShuffledHistoryOverLotsOfThings, asOfs, queryWhen)
       check(Prop.forAllNoShrink(testCaseGenerator) {
         case (bigShuffledHistoryOverLotsOfThings, asOfs, queryWhen) =>
-          worldResource
-            .use(world =>
-              IO {
+          Using.resource(makeWorld()) { world =>
                 recordEventsInWorld(
                   liftRecordings(bigShuffledHistoryOverLotsOfThings),
                   asOfs,
@@ -2244,8 +2133,6 @@ trait WorldBehaviours
                   }: _*)
                 else Prop.undecided
               }
-            )
-            .unsafeRunSync
 
         // TODO - perturb the 'asOf' values so as not to go the next revision
         // and see how that plays with the two ways of constructing a scope.
@@ -2275,9 +2162,7 @@ trait WorldBehaviours
       } yield (bigShuffledHistoryOverLotsOfThings, asOfs, queryWhen, random)
       check(Prop.forAllNoShrink(testCaseGenerator) {
         case (bigShuffledHistoryOverLotsOfThings, asOfs, queryWhen, random) =>
-          worldResource
-            .use(world =>
-              IO {
+          Using.resource(makeWorld()) { world =>
                 val revisions = recordEventsInWorld(
                   liftRecordings(bigShuffledHistoryOverLotsOfThings),
                   asOfs,
@@ -2375,8 +2260,6 @@ trait WorldBehaviours
                   }: _*)
                 else Prop.undecided
               }
-            )
-            .unsafeRunSync
       })
     }
 
@@ -2413,9 +2296,7 @@ trait WorldBehaviours
               asOfs,
               queryWhen
             ) =>
-          worldResource
-            .use(world =>
-              IO {
+          Using.resource(makeWorld()) { world =>
                 // What's being tested is the imperative behaviour of 'World'
                 // wrt its scopes - so use imperative code.
                 val scopeViaRevisionToHistoryMap =
@@ -2464,8 +2345,6 @@ trait WorldBehaviours
                   Prop.all(results.toSeq: _*)
                 else Prop.undecided
               }
-            )
-            .unsafeRunSync
       })
     }
 
@@ -2522,10 +2401,7 @@ trait WorldBehaviours
               faultyAsOfs,
               queryWhen
             ) =>
-          (worldResource -> worldResource)
-            .mapN(Tuple2.apply)
-            .use { case (utopia, distopia) =>
-              IO {
+          Using.resources(makeWorld(), makeWorld()) { (utopia, distopia) =>
                 // NOTE: we add some 'good' changes within the faulty revisions
                 // to make things more realistic prior to merging the faulty
                 // history with the good history...
@@ -2566,8 +2442,6 @@ trait WorldBehaviours
                       (utopianCase === distopianCase) :| s"${utopianCase} === distopianCase"
                   }: _*)
               }
-            }
-            .unsafeRunSync
       })
     }
 
@@ -2615,10 +2489,7 @@ trait WorldBehaviours
               asOfsAnotherWay,
               queryWhen
             ) =>
-          (worldResource -> worldResource)
-            .mapN(Tuple2.apply)
-            .use { case (worldOneWay, worldAnotherWay) =>
-              IO {
+          Using.resources(makeWorld(), makeWorld()) { (worldOneWay, worldAnotherWay) =>
                 recordEventsInWorld(
                   liftRecordings(bigShuffledHistoryOverLotsOfThingsOneWay),
                   asOfsOneWay,
@@ -2649,8 +2520,6 @@ trait WorldBehaviours
                       (caseOneWay === caseAnotherWay) :| s"The datum calculated one way: ${caseOneWay} should be the same as the other way: ${caseAnotherWay}"
                   }: _*)
               }
-            }
-            .unsafeRunSync
       })
     }
 
@@ -2707,9 +2576,7 @@ trait WorldBehaviours
                 bigShuffledHistoryOverLotsOfThings,
                 asOfs
               ) =>
-            worldResource
-              .use(world =>
-                IO {
+            Using.resource(makeWorld()) { world =>
                   recordEventsInWorld(
                     bigShuffledHistoryOverLotsOfThings,
                     asOfs,
@@ -2750,8 +2617,6 @@ trait WorldBehaviours
                     }: _*)
                   else Prop.undecided
                 }
-              )
-              .unsafeRunSync
         })
       }
     }
@@ -2797,9 +2662,7 @@ trait WorldBehaviours
                 asOfs,
                 whenAnInconsistentEventOccurs
               ) =>
-            worldResource
-              .use(world =>
-                IO {
+            Using.resource(makeWorld()) { world =>
                   var numberOfEvents = bigShuffledHistoryOverLotsOfThings.size
 
                   val sizeOfPartOne = 1 min (numberOfEvents / 2)
@@ -2899,8 +2762,6 @@ trait WorldBehaviours
                     }: _*)
                   else Prop.undecided
                 }
-              )
-              .unsafeRunSync
         })
       }
     }
@@ -3040,9 +2901,7 @@ trait WorldBehaviours
         )
         check(Prop.forAllNoShrink(testCaseGenerator) {
           case (bigShuffledHistoryOverLotsOfThings, asOfs, queryWhen) =>
-            worldResource
-              .use(world =>
-                IO {
+            Using.resource(makeWorld()) { world =>
                   recordEventsInWorld(
                     bigShuffledHistoryOverLotsOfThings,
                     asOfs,
@@ -3051,8 +2910,6 @@ trait WorldBehaviours
 
                   Prop.proved
                 }
-              )
-              .unsafeRunSync
         })
       }
     }
@@ -3121,9 +2978,7 @@ trait WorldBehaviours
         )
         check(Prop.forAllNoShrink(testCaseGenerator) {
           case (bigShuffledHistoryOverLotsOfThings, asOfs, queryWhen) =>
-            worldResource
-              .use(world =>
-                IO {
+            Using.resource(makeWorld()) { world =>
                   recordEventsInWorld(
                     bigShuffledHistoryOverLotsOfThings,
                     asOfs,
@@ -3132,8 +2987,6 @@ trait WorldBehaviours
 
                   Prop.proved
                 }
-              )
-              .unsafeRunSync
         })
       }
     }
@@ -3197,9 +3050,7 @@ trait WorldBehaviours
                 queryWhen,
                 seed
               ) =>
-            worldResource
-              .use(world =>
-                IO {
+            Using.resource(makeWorld()) { world =>
                   try {
                     recordEventsInWorld(
                       bigShuffledHistoryOverLotsOfThings,
@@ -3251,8 +3102,6 @@ trait WorldBehaviours
                     case _: UnsupportedOperationException => Prop.undecided
                   }
                 }
-              )
-              .unsafeRunSync
         },
         minSuccessful(10)
       )
@@ -3303,9 +3152,7 @@ trait WorldBehaviours
                 asOfs,
                 queryWhen
               ) =>
-            worldResource
-              .use(world =>
-                IO {
+            Using.resource(makeWorld()) { world =>
                   intercept[UnsupportedOperationException] {
                     recordEventsInWorld(
                       bigShuffledHistoryOverLotsOfThings,
@@ -3316,8 +3163,6 @@ trait WorldBehaviours
 
                   Prop.proved
                 }
-              )
-              .unsafeRunSync
         })
       }
     }
@@ -3369,9 +3214,7 @@ trait WorldBehaviours
                 whenAnAnnihilationOccurs,
                 queryWhen
               ) =>
-            worldResource
-              .use(world =>
-                IO {
+            Using.resource(makeWorld()) { world =>
                   try {
                     recordEventsInWorld(
                       bigShuffledHistoryOverLotsOfThings,
@@ -3459,8 +3302,6 @@ trait WorldBehaviours
                     case _: UnsupportedOperationException => Prop.undecided
                   }
                 }
-              )
-              .unsafeRunSync
         })
       }
     }
@@ -3519,9 +3360,7 @@ trait WorldBehaviours
               queryWhen,
               idsThatEachReferToMoreThanOneItem
             ) =>
-          worldResource
-            .use(world =>
-              IO {
+          Using.resource(makeWorld()) { world =>
                 recordEventsInWorld(
                   bigShuffledHistoryOverLotsOfThings,
                   asOfs,
@@ -3560,8 +3399,6 @@ trait WorldBehaviours
                   itemsThatShouldNotExist.isEmpty :| s"The items '$itemsThatShouldNotExist' for id: '$id' should not exist at the query time of: '$queryWhen'."
                 }): _*)
               }
-            )
-            .unsafeRunSync
       })
     }
   }
@@ -3615,9 +3452,7 @@ trait WorldBehaviours
               steps,
               annihilationWhen
             ) =>
-          worldResource
-            .use(world =>
-              IO {
+          Using.resource(makeWorld()) { world =>
                 val initialEventId = -2
 
                 world.revise(
@@ -3659,8 +3494,6 @@ trait WorldBehaviours
 
                 (steps == fredTheItem.head.datums) :| s"Expecting: ${steps}, but got: ${fredTheItem.head.datums}"
               }
-            )
-            .unsafeRunSync
       })
     }
 
@@ -3716,9 +3549,7 @@ trait WorldBehaviours
       } yield (bigShuffledHistoryOverLotsOfThings, asOfs, steps)
       check(Prop.forAllNoShrink(testCaseGenerator) {
         case (bigShuffledHistoryOverLotsOfThings, asOfs, steps) =>
-          worldResource
-            .use(world =>
-              IO {
+          Using.resource(makeWorld()) { world =>
                 recordEventsInWorld(
                   bigShuffledHistoryOverLotsOfThings,
                   asOfs,
@@ -3735,8 +3566,6 @@ trait WorldBehaviours
 
                 (steps == fredTheItem.head.datums) :| s"Expecting: ${steps}, but got: ${fredTheItem.head.datums}"
               }
-            )
-            .unsafeRunSync
       })
     }
 
@@ -3794,9 +3623,7 @@ trait WorldBehaviours
       check(
         Prop.forAllNoShrink(testCaseGenerator) {
           case (bigShuffledHistoryOverLotsOfThings, asOfs, steps) =>
-            worldResource
-              .use(world =>
-                IO {
+            Using.resource(makeWorld()) { world =>
                   recordEventsInWorld(
                     bigShuffledHistoryOverLotsOfThings,
                     asOfs,
@@ -3813,8 +3640,6 @@ trait WorldBehaviours
 
                   (steps == fredTheItem.head.datums) :| s"Expecting: ${steps}, but got: ${fredTheItem.head.datums}"
                 }
-              )
-              .unsafeRunSync
         }
       )
     }
@@ -3868,9 +3693,7 @@ trait WorldBehaviours
       check(
         Prop.forAllNoShrink(testCaseGenerator) {
           case (historyOverLotsOfThings, asOfs, steps) =>
-            worldResource
-              .use(world =>
-                IO {
+            Using.resource(makeWorld()) { world =>
                   recordEventsInWorld(
                     liftRecordings(historyOverLotsOfThings),
                     asOfs,
@@ -3887,8 +3710,6 @@ trait WorldBehaviours
 
                   (steps.toSet == fredTheItem.head.datums.toSet) :| s"Expecting: ${steps}, but got: ${fredTheItem.head.datums}"
                 }
-              )
-              .unsafeRunSync
         }
       )
     }
@@ -3935,9 +3756,7 @@ trait WorldBehaviours
               asOfs,
               queryWhen
             ) =>
-          worldResource
-            .use(world =>
-              IO {
+          Using.resource(makeWorld()) { world =>
                 recordEventsInWorld(
                   bigShuffledHistoryOverLotsOfThings,
                   asOfs,
@@ -3976,8 +3795,6 @@ trait WorldBehaviours
                   }: _*)
                 else Prop.undecided
               }
-            )
-            .unsafeRunSync
       })
     }
 
@@ -4041,9 +3858,7 @@ trait WorldBehaviours
               asOfsForSecondHistory,
               queryWhen
             ) =>
-          worldResource
-            .use(world =>
-              IO {
+          Using.resource(makeWorld()) { world =>
                 // Define a history the first time around...
 
                 recordEventsInWorld(
@@ -4091,8 +3906,6 @@ trait WorldBehaviours
                 (historyAfterAnnulments.isEmpty :| s"${historyAfterAnnulments}.isEmpty") &&
                 ((firstHistory == secondHistory) :| s"firstHistory === ${secondHistory}")
               }
-            )
-            .unsafeRunSync
       })
     }
 
@@ -4155,9 +3968,7 @@ trait WorldBehaviours
               queryWhen,
               revisionOffsetToCheckAt
             ) =>
-          worldResource
-            .use(world =>
-              IO {
+          Using.resource(makeWorld()) { world =>
                 recordEventsInWorld(
                   bigOverallShuffledHistoryOverLotsOfThings,
                   asOfs,
@@ -4200,8 +4011,6 @@ trait WorldBehaviours
                   }: _*)
                 else Prop.undecided
               }
-            )
-            .unsafeRunSync
       })
     }
 
@@ -4243,9 +4052,7 @@ trait WorldBehaviours
       check(
         Prop.forAllNoShrink(testCaseGenerator) {
           case (testCaseSubsections, asOfsForSubsections, queryWhen) =>
-            worldResource
-              .use(world =>
-                IO {
+            Using.resource(makeWorld()) { world =>
                   type ScalaFormatWorkaround =
                     Seq[Seq[
                       (
@@ -4391,8 +4198,6 @@ trait WorldBehaviours
                     Prop.all(checks: _*)
                   else Prop.undecided
                 }
-              )
-              .unsafeRunSync
         }
       )
     }
@@ -4435,9 +4240,7 @@ trait WorldBehaviours
               asOfs,
               queryWhen
             ) =>
-          worldResource
-            .use(world =>
-              IO {
+          Using.resource(makeWorld()) { world =>
                 // Define a history the first time around...
 
                 recordEventsInWorld(
@@ -4491,8 +4294,6 @@ trait WorldBehaviours
                 (historyAfterAnnulments.isEmpty :| s"${historyAfterAnnulments}.isEmpty") &&
                 ((firstHistory == secondHistory) :| s"firstHistory === ${secondHistory}")
               }
-            )
-            .unsafeRunSync
       })
     }
   }

--- a/src/test/scala/com/sageserpent/plutonium/WorldSpecSupport.scala
+++ b/src/test/scala/com/sageserpent/plutonium/WorldSpecSupport.scala
@@ -2,8 +2,8 @@ package com.sageserpent.plutonium
 
 import java.time.Instant
 import java.util.UUID
-import cats.effect.{IO, Resource}
-import cats.implicits._
+import scala.util.Using
+
 import com.sageserpent.americium
 import com.sageserpent.americium._
 import com.sageserpent.americium.utilities.randomEnrichment._
@@ -1041,21 +1041,16 @@ trait WorldSpecSupport extends Assertions with SharedGenerators {
     }
   }
 }
-
 trait WorldResource {
-  val worldResource: Resource[IO, World]
+  def makeWorld(): World
 }
 
 trait WorldReferenceImplementationResource extends WorldResource {
-  val worldResource: Resource[IO, World] =
-    Resource.fromAutoCloseable(IO {
-      new WorldReferenceImplementation with WorldContracts
-    })
+  override def makeWorld(): World =
+    new WorldReferenceImplementation with WorldContracts
 }
 
 trait WorldEfficientInMemoryImplementationResource extends WorldResource {
-  val worldResource: Resource[IO, World] =
-    Resource.fromAutoCloseable(IO {
-      new WorldEfficientInMemoryImplementation with WorldContracts
-    })
+  override def makeWorld(): World =
+    new WorldEfficientInMemoryImplementation with WorldContracts
 }

--- a/src/test/scala/com/sageserpent/plutonium/storage/BlobStorageConformanceAgainstReferenceImplementation.scala
+++ b/src/test/scala/com/sageserpent/plutonium/storage/BlobStorageConformanceAgainstReferenceImplementation.scala
@@ -1,7 +1,5 @@
 package com.sageserpent.plutonium.storage
 
-import cats.effect.unsafe.implicits.global
-import cats.effect.{IO, Resource}
 import com.sageserpent.plutonium.efficient.{
   BlobStorage,
   ItemStateStorage,
@@ -25,20 +23,18 @@ import scalikejdbc.ConnectionPool
 import java.time.Instant
 import java.util.UUID
 import scala.collection.mutable
-import scala.util.Try
+import scala.util.{Try, Using}
 
 trait BlobStorageResource {
-  val blobStorageResource: Resource[IO, Timeline.BlobStorage]
+  def blobStorage(implicit manager: Using.Manager): Timeline.BlobStorage
 }
 
 trait BlobStorageOnH2DatabaseSetupResource extends ConnectionPoolResource {
-  override def connectionPoolResource: Resource[IO, ConnectionPool] =
-    for {
-      connectionPool <- super.connectionPoolResource
-      _ <- Resource.make(BlobStorageOnH2.setupDatabaseTables(connectionPool))(
-        _ => IO {}
-      )
-    } yield connectionPool
+  def connectionPool(implicit manager: Using.Manager): ConnectionPool = {
+    val pool = createConnectionPool()
+    BlobStorageOnH2.setupDatabaseTables(pool)
+    pool
+  }
 }
 
 object BlobStorageConformanceAgainstReferenceImplementation
@@ -104,177 +100,174 @@ trait BlobStorageConformanceAgainstReferenceImplementation
       forAll(operationsGenerator, MinSuccessful(200)) { operations =>
         println(counter)
         counter += 1
-        blobStorageResource
-          .use(blobStorage =>
-            IO {
-              val pairsOfTraineeAndExemplarImplementations: mutable.Queue[
-                (Timeline.BlobStorage, Timeline.BlobStorage)
-              ] =
-                mutable.Queue.empty
+        Using.Manager { manager =>
+          val storage = blobStorage(manager)
+          val pairsOfTraineeAndExemplarImplementations: mutable.Queue[
+            (Timeline.BlobStorage, Timeline.BlobStorage)
+          ] =
+            mutable.Queue.empty
 
-              pairsOfTraineeAndExemplarImplementations.enqueue(
-                blobStorage -> BlobStorageReferenceImplementation.empty
-              )
+          pairsOfTraineeAndExemplarImplementations.enqueue(
+            storage -> BlobStorageReferenceImplementation.empty
+          )
 
-              for {
-                operation <- operations
-              } {
-                def checkResults(when: ItemStateUpdateTime, inclusive: Boolean)(
-                    traineeResult: Seq[UniqueItemSpecification],
-                    traineeTimeslice: BlobStorage.Timeslice[
-                      ItemStateStorage.SnapshotBlob
-                    ]
-                )(
-                    exemplarResult: Seq[UniqueItemSpecification],
-                    exemplarTimeslice: BlobStorage.Timeslice[
-                      ItemStateStorage.SnapshotBlob
-                    ]
-                ): Unit = {
-                  try {
-                    traineeResult should contain theSameElementsAs exemplarResult
-                  } catch {
-                    case exception: Exception =>
-                      val traineeResultSet  = traineeResult.toSet
-                      val exemplarResultSet = exemplarResult.toSet
-                      println(
-                        s"Failure to match unique item specifications, got:\n$traineeResultSet, expected:\n$exemplarResultSet, left difference:\n${traineeResultSet
-                            .diff(exemplarResultSet)}, right difference:\n${exemplarResultSet
-                            .diff(traineeResultSet)}\nwhen: $when, inclusive: $inclusive"
-                      )
-                      throw exception
-                  }
+          for {
+            operation <- operations
+          } {
+            def checkResults(when: ItemStateUpdateTime, inclusive: Boolean)(
+                traineeResult: Seq[UniqueItemSpecification],
+                traineeTimeslice: BlobStorage.Timeslice[
+                  ItemStateStorage.SnapshotBlob
+                ]
+            )(
+                exemplarResult: Seq[UniqueItemSpecification],
+                exemplarTimeslice: BlobStorage.Timeslice[
+                  ItemStateStorage.SnapshotBlob
+                ]
+            ): Unit = {
+              try {
+                traineeResult should contain theSameElementsAs exemplarResult
+              } catch {
+                case exception: Exception =>
+                  val traineeResultSet  = traineeResult.toSet
+                  val exemplarResultSet = exemplarResult.toSet
+                  println(
+                    s"Failure to match unique item specifications, got:\n$traineeResultSet, expected:\n$exemplarResultSet, left difference:\n${traineeResultSet
+                        .diff(exemplarResultSet)}, right difference:\n${exemplarResultSet
+                        .diff(traineeResultSet)}\nwhen: $when, inclusive: $inclusive"
+                  )
+                  throw exception
+              }
 
-                  // NOTE: just use the result from the exemplar, as there is no
-                  // guarantee that the result contents come back in the same
-                  // order from the trainee and the exemplar. If execution
-                  // reaches this point, we know there are the same unique item
-                  // specifications with the same multiplicities, so there is no
-                  // harm in doing this.
+              // NOTE: just use the result from the exemplar, as there is no
+              // guarantee that the result contents come back in the same
+              // order from the trainee and the exemplar. If execution
+              // reaches this point, we know there are the same unique item
+              // specifications with the same multiplicities, so there is no
+              // harm in doing this.
 
-                  if (traineeResult.nonEmpty) println("*** GOT RESULTS ***")
+              if (traineeResult.nonEmpty) println("*** GOT RESULTS ***")
 
-                  exemplarResult.foreach { uniqueItemSpecification =>
-                    withClue(
-                      s"Retrieved unique item specification mismatch for unique item specification: $uniqueItemSpecification\n"
-                    ) {
-                      traineeTimeslice.uniqueItemQueriesFor(
-                        uniqueItemSpecification
-                      ) should contain theSameElementsAs exemplarTimeslice
-                        .uniqueItemQueriesFor(
-                          uniqueItemSpecification
-                        )
-                    }
-
-                    withClue(
-                      s"Retrieved blob mismatch for unique item specification: $uniqueItemSpecification\n"
-                    ) {
-                      // NOTE: wrap the retrievals in `Try` because sometimes
-                      // `uniqueItemSpecification` is too wide-ranging and would
-                      // match more than one snapshot.
-                      Try {
-                        traineeTimeslice
-                          .snapshotBlobFor(
-                            uniqueItemSpecification
-                          )
-                      }.toEither.left.map(_.getClass) should be(Try {
-                        exemplarTimeslice
-                          .snapshotBlobFor(
-                            uniqueItemSpecification
-                          )
-                      }.toEither.left.map(_.getClass))
-                    }
-                  }
+              exemplarResult.foreach { uniqueItemSpecification =>
+                withClue(
+                  s"Retrieved unique item specification mismatch for unique item specification: $uniqueItemSpecification\n"
+                ) {
+                  traineeTimeslice.uniqueItemQueriesFor(
+                    uniqueItemSpecification
+                  ) should contain theSameElementsAs exemplarTimeslice
+                    .uniqueItemQueriesFor(
+                      uniqueItemSpecification
+                    )
                 }
 
-                val (trainee, exemplar) =
-                  pairsOfTraineeAndExemplarImplementations.dequeue()
-
-                operation match {
-                  case Revision(recordingDatums) =>
-                    val (builderFromTrainee, builderFromExemplar) = trainee
-                      .openRevision() -> exemplar.openRevision()
-
-                    for {
-                      (when, snapshotBlobs) <- recordingDatums
-                    } {
-                      builderFromTrainee.record(when, snapshotBlobs)
-                      builderFromExemplar.record(when, snapshotBlobs)
-                    }
-
-                    val (newTrainee, newExemplar) = builderFromTrainee
-                      .build() -> builderFromExemplar.build()
-
-                    pairsOfTraineeAndExemplarImplementations.enqueue(
-                      newTrainee -> newExemplar
-                    )
-
-                    if (
-                      maximumNumberOfAlternativeBlobStorages > pairsOfTraineeAndExemplarImplementations.size
-                    ) {
-                      pairsOfTraineeAndExemplarImplementations.enqueue(
-                        trainee -> exemplar
-                      )
-                    }
-
-                  case Retaining(when) =>
-                    val (newTrainee, newExemplar) = trainee
-                      .retainUpTo(when) -> exemplar
-                      .retainUpTo(when)
-
-                    pairsOfTraineeAndExemplarImplementations.enqueue(
-                      newTrainee -> newExemplar
-                    )
-
-                    if (
-                      maximumNumberOfAlternativeBlobStorages > pairsOfTraineeAndExemplarImplementations.size
-                    ) {
-                      pairsOfTraineeAndExemplarImplementations.enqueue(
-                        trainee -> exemplar
-                      )
-                    }
-
-                  case Querying(
-                        when,
-                        Left(uniqueItemSpecification),
-                        inclusive
-                      ) =>
-                    val traineeTimeslice  = trainee.timeSlice(when, inclusive)
-                    val exemplarTimeslice = exemplar.timeSlice(when, inclusive)
-                    val (traineeResult, exemplarResult) = traineeTimeslice
-                      .uniqueItemQueriesFor(
+                withClue(
+                  s"Retrieved blob mismatch for unique item specification: $uniqueItemSpecification\n"
+                ) {
+                  // NOTE: wrap the retrievals in `Try` because sometimes
+                  // `uniqueItemSpecification` is too wide-ranging and would
+                  // match more than one snapshot.
+                  Try {
+                    traineeTimeslice
+                      .snapshotBlobFor(
                         uniqueItemSpecification
-                      ) -> exemplarTimeslice
-                      .uniqueItemQueriesFor(uniqueItemSpecification)
-
-                    checkResults(when, inclusive)(
-                      traineeResult,
-                      traineeTimeslice
-                    )(exemplarResult, exemplarTimeslice)
-
-                    pairsOfTraineeAndExemplarImplementations.enqueue(
-                      trainee -> exemplar
-                    )
-
-                  case Querying(when, Right(clazz), inclusive) =>
-                    val traineeTimeslice  = trainee.timeSlice(when, inclusive)
-                    val exemplarTimeslice = exemplar.timeSlice(when, inclusive)
-                    val (traineeResult, exemplarResult) = traineeTimeslice
-                      .uniqueItemQueriesFor(clazz) -> exemplarTimeslice
-                      .uniqueItemQueriesFor(clazz)
-
-                    checkResults(when, inclusive)(
-                      traineeResult,
-                      traineeTimeslice
-                    )(exemplarResult, exemplarTimeslice)
-
-                    pairsOfTraineeAndExemplarImplementations.enqueue(
-                      trainee -> exemplar
-                    )
+                      )
+                  }.toEither.left.map(_.getClass) should be(Try {
+                    exemplarTimeslice
+                      .snapshotBlobFor(
+                        uniqueItemSpecification
+                      )
+                  }.toEither.left.map(_.getClass))
                 }
               }
             }
-          )
-          .unsafeRunSync()
+
+            val (trainee, exemplar) =
+              pairsOfTraineeAndExemplarImplementations.dequeue()
+
+            operation match {
+              case Revision(recordingDatums) =>
+                val (builderFromTrainee, builderFromExemplar) = trainee
+                  .openRevision() -> exemplar.openRevision()
+
+                for {
+                  (when, snapshotBlobs) <- recordingDatums
+                } {
+                  builderFromTrainee.record(when, snapshotBlobs)
+                  builderFromExemplar.record(when, snapshotBlobs)
+                }
+
+                val (newTrainee, newExemplar) = builderFromTrainee
+                  .build() -> builderFromExemplar.build()
+
+                pairsOfTraineeAndExemplarImplementations.enqueue(
+                  newTrainee -> newExemplar
+                )
+
+                if (
+                  maximumNumberOfAlternativeBlobStorages > pairsOfTraineeAndExemplarImplementations.size
+                ) {
+                  pairsOfTraineeAndExemplarImplementations.enqueue(
+                    trainee -> exemplar
+                  )
+                }
+
+              case Retaining(when) =>
+                val (newTrainee, newExemplar) = trainee
+                  .retainUpTo(when) -> exemplar
+                  .retainUpTo(when)
+
+                pairsOfTraineeAndExemplarImplementations.enqueue(
+                  newTrainee -> newExemplar
+                )
+
+                if (
+                  maximumNumberOfAlternativeBlobStorages > pairsOfTraineeAndExemplarImplementations.size
+                ) {
+                  pairsOfTraineeAndExemplarImplementations.enqueue(
+                    trainee -> exemplar
+                  )
+                }
+
+              case Querying(
+                    when,
+                    Left(uniqueItemSpecification),
+                    inclusive
+                  ) =>
+                val traineeTimeslice  = trainee.timeSlice(when, inclusive)
+                val exemplarTimeslice = exemplar.timeSlice(when, inclusive)
+                val (traineeResult, exemplarResult) = traineeTimeslice
+                  .uniqueItemQueriesFor(
+                    uniqueItemSpecification
+                  ) -> exemplarTimeslice
+                  .uniqueItemQueriesFor(uniqueItemSpecification)
+
+                checkResults(when, inclusive)(
+                  traineeResult,
+                  traineeTimeslice
+                )(exemplarResult, exemplarTimeslice)
+
+                pairsOfTraineeAndExemplarImplementations.enqueue(
+                  trainee -> exemplar
+                )
+
+              case Querying(when, Right(clazz), inclusive) =>
+                val traineeTimeslice  = trainee.timeSlice(when, inclusive)
+                val exemplarTimeslice = exemplar.timeSlice(when, inclusive)
+                val (traineeResult, exemplarResult) = traineeTimeslice
+                  .uniqueItemQueriesFor(clazz) -> exemplarTimeslice
+                  .uniqueItemQueriesFor(clazz)
+
+                checkResults(when, inclusive)(
+                  traineeResult,
+                  traineeTimeslice
+                )(exemplarResult, exemplarTimeslice)
+
+                pairsOfTraineeAndExemplarImplementations.enqueue(
+                  trainee -> exemplar
+                )
+            }
+          }
+        }.get
       }
     }
   }
@@ -283,12 +276,14 @@ trait BlobStorageConformanceAgainstReferenceImplementation
 trait BlobStorageOnH2Resource
     extends BlobStorageResource
     with BlobStorageOnH2DatabaseSetupResource {
-  override val blobStorageResource: Resource[IO, Timeline.BlobStorage] =
-    connectionPoolResource.flatMap(connectionPool =>
-      Resource.make(IO {
-        BlobStorageOnH2.empty(connectionPool): Timeline.BlobStorage
-      })(_ => IO {})
+  override def blobStorage(implicit manager: Using.Manager): Timeline.BlobStorage = {
+    val pool = connectionPool
+    manager(BlobStorageOnH2.empty(pool): Timeline.BlobStorage)(
+      new Using.Releasable[Timeline.BlobStorage] {
+        override def release(resource: Timeline.BlobStorage): Unit = ()
+      }
     )
+  }
 }
 
 class BlobStorageOnH2Spec


### PR DESCRIPTION
Refactored the `World` test suite to use `scala.util.Using` instead of Cats Effect `Resource`. This change was motivated by the need to avoid thread scheduler interference with exception-based control flow in tests. Verified that all relevant tests pass across both reference and efficient `World` implementations.

---
*PR created automatically by Jules for task [8512842314988253087](https://jules.google.com/task/8512842314988253087) started by @sageserpent-open*