### PR TITLE
Port WorldBehaviours tests to JUnit 5, Americium, and Expecty

### DIFF
--- a/src/test/scala/com/sageserpent/plutonium/AmericiumInfrastructureSmokeTest.scala
+++ b/src/test/scala/com/sageserpent/plutonium/AmericiumInfrastructureSmokeTest.scala
@@ -7,6 +7,7 @@ import org.scalatest.matchers.should.Matchers
 import com.sageserpent.plutonium.utilities.Finite
 
 class AmericiumInfrastructureSmokeTest extends AnyFlatSpec with Matchers with WorldSpecSupportAmericium {
+  import org.junit.jupiter.api.Assertions._
   "WorldSpecSupportAmericium" should "generate recordings" in {
     val trials = mixedRecordingsGroupedByIdTrials(forbidAnnihilations = false)
 

--- a/src/test/scala/com/sageserpent/plutonium/WorldBehaviourAmericium.scala
+++ b/src/test/scala/com/sageserpent/plutonium/WorldBehaviourAmericium.scala
@@ -19,11 +19,22 @@ object WorldBehaviourAmericium {
     }
   }
 
-  case class TestCase(
+  case class RelatedItemTestCase(
       referencedHistoryRecordingsGroupedById: List[
         WorldSpecSupportAmericium#RecordingsForAnId
       ],
       referringHistoryRecordingsGroupedById: List[
+        WorldSpecSupportAmericium#RecordingsForAnId
+      ],
+      bigShuffledHistoryOverLotsOfThings: Vector[
+        Seq[(Option[(Unbounded[Instant], Event)], Int)]
+      ],
+      asOfs: List[Instant],
+      queryWhen: Unbounded[Instant]
+  )
+
+  case class HistoryTestCase(
+      recordingsGroupedById: List[
         WorldSpecSupportAmericium#RecordingsForAnId
       ],
       bigShuffledHistoryOverLotsOfThings: Vector[
@@ -38,7 +49,7 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
   this: WorldResourceAmericium =>
 
   import WorldBehaviourAmericium.ExpectyFlavouredAssert.assert
-  import WorldBehaviourAmericium.TestCase
+  import WorldBehaviourAmericium.{HistoryTestCase, RelatedItemTestCase}
 
   @TestFactory
   def worldWithNoHistory() = {
@@ -67,6 +78,76 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
   }
 
   @TestFactory
+  def revealAllTheHistoryUpToTheWhenLimitOfAScopeMadeFromIt() = {
+    val testCaseTrials = for {
+      recordingsGroupedById <- recordingsGroupedByIdTrials(
+        forbidAnnihilations = false
+      )
+      obsoleteRecordingsGroupedById <-
+        nonConflictingRecordingsGroupedByIdTrials
+      shuffledRecordings <- shuffleRecordingsPreservingRelativeOrderOfEventsAtTheSameWhen(
+        recordingsGroupedById
+      )
+      shuffledObsoleteRecordings <- shuffleRecordingsPreservingRelativeOrderOfEventsAtTheSameWhen(
+        obsoleteRecordingsGroupedById
+      )
+      bigShuffledHistoryOverLotsOfThings <- intersperseObsoleteEventsAmericium(
+        shuffledRecordings,
+        shuffledObsoleteRecordings
+      )
+      asOfs <- instantTrials
+        .listsOfSize(bigShuffledHistoryOverLotsOfThings.size)
+        .map(_.sorted)
+      queryWhen <- unboundedInstantTrials
+    } yield HistoryTestCase(
+      recordingsGroupedById,
+      bigShuffledHistoryOverLotsOfThings.map(_.toSeq).toVector,
+      asOfs,
+      queryWhen
+    )
+    testCaseTrials.withLimit(200).dynamicTests {
+      case HistoryTestCase(
+            recordingsGroupedById,
+            bigShuffledHistoryOverLotsOfThings,
+            asOfs,
+            queryWhen
+          ) =>
+        Using.resource(makeWorld()) { world =>
+          recordEventsInWorld(
+            bigShuffledHistoryOverLotsOfThings,
+            asOfs,
+            world
+          )
+
+          val scope = world.scopeFor(queryWhen, world.nextRevision)
+
+          val checks = for {
+            recording <- recordingsGroupedById
+            RecordingsNoLaterThan(
+              historyId,
+              historiesFrom,
+              pertinentRecordings,
+              _,
+              _
+            ) <- recording.thePartNoLaterThan(queryWhen).toList
+            Seq(history) = historiesFrom(scope)
+          } yield (
+            historyId,
+            history.datums,
+            pertinentRecordings.map(_._1)
+          )
+
+          for ((_, actualHistory, expectedHistory) <- checks) {
+            assert(actualHistory.length == expectedHistory.length)
+            for (((actual, expected), _) <- (actualHistory zip expectedHistory).zipWithIndex) {
+              assert(actual == expected)
+            }
+          }
+        }
+    }
+  }
+
+  @TestFactory
   def revealAllTheHistoryOfARelatedItemUpToTheWhenLimitOfAScopeMadeFromIt() = {
     val testCaseTrials = for {
       referencedHistoryRecordingsGroupedById <-
@@ -91,7 +172,7 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
         .listsOfSize(bigShuffledHistoryOverLotsOfThings.size)
         .map(_.sorted)
       queryWhen <- unboundedInstantTrials
-    } yield TestCase(
+    } yield RelatedItemTestCase(
       referencedHistoryRecordingsGroupedById,
       referringHistoryRecordingsGroupedById,
       bigShuffledHistoryOverLotsOfThings.map(_.toSeq).toVector,
@@ -99,7 +180,7 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
       queryWhen
     )
     testCaseTrials.withLimit(200).dynamicTests {
-      case TestCase(
+      case RelatedItemTestCase(
             referencedHistoryRecordingsGroupedById,
             referringHistoryRecordingsGroupedById,
             bigShuffledHistoryOverLotsOfThings,
@@ -193,7 +274,7 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
         .listsOfSize(bigShuffledHistoryOverLotsOfThings.size)
         .map(_.sorted)
       queryWhen <- unboundedInstantTrials
-    } yield TestCase(
+    } yield RelatedItemTestCase(
       referencedHistoryRecordingsGroupedById,
       referringHistoryRecordingsGroupedById,
       bigShuffledHistoryOverLotsOfThings.map(_.toSeq).toVector,
@@ -201,7 +282,7 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
       queryWhen
     )
     testCaseTrials.withLimit(12).dynamicTests {
-      case TestCase(
+      case RelatedItemTestCase(
             referencedHistoryRecordingsGroupedById,
             referringHistoryRecordingsGroupedById,
             bigShuffledHistoryOverLotsOfThings,

--- a/src/test/scala/com/sageserpent/plutonium/WorldBehaviourAmericium.scala
+++ b/src/test/scala/com/sageserpent/plutonium/WorldBehaviourAmericium.scala
@@ -97,6 +97,7 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
         .listsOfSize(bigShuffledHistoryOverLotsOfThings.size)
         .map(_.sorted)
       queryWhen <- unboundedInstantTrials
+      if recordingsGroupedById.exists(_.thePartNoLaterThan(queryWhen).isDefined)
     } yield HistoryTestCase(
       recordingsGroupedById,
       bigShuffledHistoryOverLotsOfThings.map(_.toSeq).toVector,
@@ -122,24 +123,19 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
           val checks = for {
             recording <- recordingsGroupedById
             RecordingsNoLaterThan(
-              historyId,
+              _,
               historiesFrom,
               pertinentRecordings,
               _,
               _
             ) <- recording.thePartNoLaterThan(queryWhen).toList
             Seq(history) = historiesFrom(scope)
-          } yield (
-            historyId,
-            history.datums,
-            pertinentRecordings.map(_._1)
-          )
+          } yield history.datums -> pertinentRecordings.map(_._1)
 
-          for ((_, actualHistory, expectedHistory) <- checks) {
-            assert(actualHistory.length == expectedHistory.length)
-            for (((actual, expected), _) <- (actualHistory zip expectedHistory).zipWithIndex) {
-              assert(actual == expected)
-            }
+          assert(checks.nonEmpty)
+
+          for ((actualHistory, expectedHistory) <- checks) {
+            assert(actualHistory == expectedHistory)
           }
         }
     }
@@ -170,6 +166,13 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
         .listsOfSize(bigShuffledHistoryOverLotsOfThings.size)
         .map(_.sorted)
       queryWhen <- unboundedInstantTrials
+      if (for {
+        referringHistoryRecording <- referringHistoryRecordingsGroupedById
+        _ <- referringHistoryRecording.thePartNoLaterThan(queryWhen).toList
+        referencedHistoryRecording <-
+          referencedHistoryRecordingsGroupedById
+        _ <- referencedHistoryRecording.thePartNoLaterThan(queryWhen).toList
+      } yield ()).nonEmpty
     } yield RelatedItemTestCase(
       referencedHistoryRecordingsGroupedById,
       referringHistoryRecordingsGroupedById,
@@ -198,7 +201,7 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
             for {
               referringHistoryRecording <- referringHistoryRecordingsGroupedById
               RecordingsNoLaterThan(
-                referringHistoryId,
+                _,
                 referringHistoriesFrom,
                 _,
                 _,
@@ -213,34 +216,18 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
                 _,
                 _
               ) <- referencedHistoryRecording.thePartNoLaterThan(queryWhen).toList
-              referringHistories = referringHistoriesFrom(scope)
-              if referringHistories.nonEmpty
-              referringHistory =
-                referringHistories.head.asInstanceOf[ReferringHistory]
+              Seq(referringHistory: ReferringHistory) =
+                referringHistoriesFrom(scope)
               if referringHistory.referencedHistories
                 .get(referencedHistoryId)
                 .exists(!_.asInstanceOf[ItemExtensionApi].isGhost)
-            } yield (
-              referringHistoryId,
-              referencedHistoryId,
-              referringHistory.referencedDatums(referencedHistoryId),
-              pertinentRecordings.map(_._1)
-            )
+            } yield referringHistory.referencedDatums(
+              referencedHistoryId
+            ) -> pertinentRecordings.map(_._1)
 
-          for {
-            (
-              referringHistoryId,
-              referencedHistoryId,
-              actualHistory,
-              expectedHistory
-            ) <- checks
-          } {
-            assert(actualHistory.length == expectedHistory.length)
-            for (
-              ((actual, expected), _) <-
-                (actualHistory zip expectedHistory).zipWithIndex
-            ) {
-              assert(actual == expected)
+          if (checks.nonEmpty) {
+            for ((actualHistory, expectedHistory) <- checks) {
+              assert(actualHistory == expectedHistory)
             }
           }
         }
@@ -272,6 +259,13 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
         .listsOfSize(bigShuffledHistoryOverLotsOfThings.size)
         .map(_.sorted)
       queryWhen <- unboundedInstantTrials
+      if (for {
+        referringHistoryRecording <- referringHistoryRecordingsGroupedById
+        _ <- referringHistoryRecording.thePartNoLaterThan(queryWhen).toList
+        referencedHistoryRecording <-
+          referencedHistoryRecordingsGroupedById
+        _ <- referencedHistoryRecording.doesNotExistAt(queryWhen).toList
+      } yield ()).nonEmpty
     } yield RelatedItemTestCase(
       referencedHistoryRecordingsGroupedById,
       referringHistoryRecordingsGroupedById,
@@ -296,7 +290,7 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
 
           val scope = world.scopeFor(queryWhen, world.nextRevision)
 
-          val checks: List[(Any, History)] =
+          val checks: List[History] =
             for {
               referringHistoryRecording <- referringHistoryRecordingsGroupedById
               RecordingsNoLaterThan(
@@ -313,18 +307,18 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
                 referencedHistoriesFrom,
                 _
               ) <- referencedHistoryRecording.doesNotExistAt(queryWhen).toList
-              referringHistories = referringHistoriesFrom(scope)
-              if referringHistories.nonEmpty
-              referringHistory =
-                referringHistories.head.asInstanceOf[ReferringHistory]
+              Seq(referringHistory: ReferringHistory) =
+                referringHistoriesFrom(scope)
               if referringHistory.referencedHistories
                 .get(referencedHistoryId)
                 .exists(!_.asInstanceOf[ItemExtensionApi].isGhost)
               Seq(referencedHistory) = referencedHistoriesFrom(scope)
-            } yield (referencedHistoryId, referencedHistory)
+            } yield referencedHistory
 
-          for ((_, actualHistory) <- checks) {
-            assert(actualHistory.datums.isEmpty)
+          if (checks.nonEmpty) {
+            for (referencedHistory <- checks) {
+              assert(referencedHistory.datums.isEmpty)
+            }
           }
         }
     }

--- a/src/test/scala/com/sageserpent/plutonium/WorldBehaviourAmericium.scala
+++ b/src/test/scala/com/sageserpent/plutonium/WorldBehaviourAmericium.scala
@@ -4,7 +4,7 @@ import com.sageserpent.americium.Trials.api
 import com.sageserpent.americium.junit5._
 import com.sageserpent.plutonium.World.Revision
 import com.sageserpent.plutonium.utilities.Unbounded
-import org.junit.jupiter.api.TestFactory
+import org.junit.jupiter.api.{Test, TestFactory}
 
 import _root_.java.time.Instant
 import scala.util.Using
@@ -68,12 +68,10 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
     }
   }
 
-  @TestFactory
-  def haveNoCurrentRevision() = {
-    api.only(()).withLimit(1).dynamicTests { _ =>
-      Using.resource(makeWorld()) { world =>
-        assert(World.initialRevision == world.nextRevision)
-      }
+  @Test
+  def haveNoCurrentRevision(): Unit = {
+    Using.resource(makeWorld()) { world =>
+      assert(World.initialRevision == world.nextRevision)
     }
   }
 

--- a/src/test/scala/com/sageserpent/plutonium/WorldBehaviourAmericium.scala
+++ b/src/test/scala/com/sageserpent/plutonium/WorldBehaviourAmericium.scala
@@ -1,0 +1,263 @@
+package com.sageserpent.plutonium
+
+import com.sageserpent.americium.Trials.api
+import com.sageserpent.americium.junit5._
+import com.sageserpent.plutonium.World.Revision
+import com.sageserpent.plutonium.utilities.Unbounded
+import org.junit.jupiter.api.TestFactory
+
+import _root_.java.time.Instant
+import scala.util.Using
+
+object WorldBehaviourAmericium {
+  object ExpectyFlavouredAssert {
+    import com.eed3si9n.expecty.Expecty
+
+    val assert: Expecty = new Expecty {
+      override val showLocation: Boolean = true
+      override val showTypes: Boolean    = true
+    }
+  }
+
+  case class TestCase(
+      referencedHistoryRecordingsGroupedById: List[
+        WorldSpecSupportAmericium#RecordingsForAnId
+      ],
+      referringHistoryRecordingsGroupedById: List[
+        WorldSpecSupportAmericium#RecordingsForAnId
+      ],
+      bigShuffledHistoryOverLotsOfThings: Vector[
+        Seq[(Option[(Unbounded[Instant], Event)], Int)]
+      ],
+      asOfs: List[Instant],
+      queryWhen: Unbounded[Instant]
+  )
+}
+
+trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
+  this: WorldResourceAmericium =>
+
+  import WorldBehaviourAmericium.ExpectyFlavouredAssert.assert
+  import WorldBehaviourAmericium.TestCase
+
+  @TestFactory
+  def worldWithNoHistory() = {
+    val scopeTrials = for {
+      when <- unboundedInstantTrials
+      asOf <- instantTrials
+    } yield when -> asOf
+
+    scopeTrials.withLimit(200).dynamicTests { case (when, asOf) =>
+      Using.resource(makeWorld()) { world =>
+        val scope = world.scopeFor(when = when, asOf = asOf)
+        val exampleBitemporal = Bitemporal.wildcard[NonExistentHistory]()
+
+        assert(scope.render(exampleBitemporal).isEmpty)
+      }
+    }
+  }
+
+  @TestFactory
+  def haveNoCurrentRevision() = {
+    api.only(()).withLimit(1).dynamicTests { _ =>
+      Using.resource(makeWorld()) { world =>
+        assert(World.initialRevision == world.nextRevision)
+      }
+    }
+  }
+
+  @TestFactory
+  def revealAllTheHistoryOfARelatedItemUpToTheWhenLimitOfAScopeMadeFromIt() = {
+    val testCaseTrials = for {
+      referencedHistoryRecordingsGroupedById <-
+        referencedHistoryRecordingsGroupedByIdTrials(
+          forbidAnnihilations = false
+        )
+      referringHistoryRecordingsGroupedById <-
+        referringHistoryRecordingsGroupedByIdTrials()
+      obsoleteRecordingsGroupedById <-
+        nonConflictingRecordingsGroupedByIdTrials
+      shuffledRecordings <- shuffleRecordingsPreservingRelativeOrderOfEventsAtTheSameWhen(
+        referencedHistoryRecordingsGroupedById ++ referringHistoryRecordingsGroupedById
+      )
+      shuffledObsoleteRecordings <- shuffleRecordingsPreservingRelativeOrderOfEventsAtTheSameWhen(
+        obsoleteRecordingsGroupedById
+      )
+      bigShuffledHistoryOverLotsOfThings <- intersperseObsoleteEventsAmericium(
+        shuffledRecordings,
+        shuffledObsoleteRecordings
+      )
+      asOfs <- instantTrials
+        .listsOfSize(bigShuffledHistoryOverLotsOfThings.size)
+        .map(_.sorted)
+      queryWhen <- unboundedInstantTrials
+    } yield TestCase(
+      referencedHistoryRecordingsGroupedById,
+      referringHistoryRecordingsGroupedById,
+      bigShuffledHistoryOverLotsOfThings.map(_.toSeq).toVector,
+      asOfs,
+      queryWhen
+    )
+    testCaseTrials.withLimit(200).dynamicTests {
+      case TestCase(
+            referencedHistoryRecordingsGroupedById,
+            referringHistoryRecordingsGroupedById,
+            bigShuffledHistoryOverLotsOfThings,
+            asOfs,
+            queryWhen
+          ) =>
+        Using.resource(makeWorld()) { world =>
+          recordEventsInWorld(
+            bigShuffledHistoryOverLotsOfThings,
+            asOfs,
+            world
+          )
+
+          val scope = world.scopeFor(queryWhen, world.nextRevision)
+
+          val checks =
+            for {
+              referringHistoryRecording <- referringHistoryRecordingsGroupedById
+              RecordingsNoLaterThan(
+                referringHistoryId,
+                referringHistoriesFrom,
+                _,
+                _,
+                _
+              ) <- referringHistoryRecording.thePartNoLaterThan(queryWhen).toList
+              referencedHistoryRecording <-
+                referencedHistoryRecordingsGroupedById
+              RecordingsNoLaterThan(
+                referencedHistoryId,
+                _,
+                pertinentRecordings,
+                _,
+                _
+              ) <- referencedHistoryRecording.thePartNoLaterThan(queryWhen).toList
+              referringHistories = referringHistoriesFrom(scope)
+              if referringHistories.nonEmpty
+              referringHistory =
+                referringHistories.head.asInstanceOf[ReferringHistory]
+              if referringHistory.referencedHistories
+                .get(referencedHistoryId)
+                .exists(!_.asInstanceOf[ItemExtensionApi].isGhost)
+            } yield (
+              referringHistoryId,
+              referencedHistoryId,
+              referringHistory.referencedDatums(referencedHistoryId),
+              pertinentRecordings.map(_._1)
+            )
+
+          for {
+            (
+              referringHistoryId,
+              referencedHistoryId,
+              actualHistory,
+              expectedHistory
+            ) <- checks
+          } {
+            assert(actualHistory.length == expectedHistory.length)
+            for (
+              ((actual, expected), _) <-
+                (actualHistory zip expectedHistory).zipWithIndex
+            ) {
+              assert(actual == expected)
+            }
+          }
+        }
+    }
+  }
+
+  @TestFactory
+  def considerAReferenceToARelatedItemInAnEventAsBeingDefining() = {
+    val testCaseTrials = for {
+      referencedHistoryRecordingsGroupedById <-
+        referencedHistoryRecordingsGroupedByIdTrials(
+          forbidAnnihilations = false
+        )
+      referringHistoryRecordingsGroupedById <-
+        referringHistoryRecordingsGroupedByIdTrials()
+      obsoleteRecordingsGroupedById <-
+        nonConflictingRecordingsGroupedByIdTrials
+      shuffledRecordings <- shuffleRecordingsPreservingRelativeOrderOfEventsAtTheSameWhen(
+        referencedHistoryRecordingsGroupedById ++ referringHistoryRecordingsGroupedById
+      )
+      shuffledObsoleteRecordings <- shuffleRecordingsPreservingRelativeOrderOfEventsAtTheSameWhen(
+        obsoleteRecordingsGroupedById
+      )
+      bigShuffledHistoryOverLotsOfThings <- intersperseObsoleteEventsAmericium(
+        shuffledRecordings,
+        shuffledObsoleteRecordings
+      )
+      asOfs <- instantTrials
+        .listsOfSize(bigShuffledHistoryOverLotsOfThings.size)
+        .map(_.sorted)
+      queryWhen <- unboundedInstantTrials
+    } yield TestCase(
+      referencedHistoryRecordingsGroupedById,
+      referringHistoryRecordingsGroupedById,
+      bigShuffledHistoryOverLotsOfThings.map(_.toSeq).toVector,
+      asOfs,
+      queryWhen
+    )
+    testCaseTrials.withLimit(12).dynamicTests {
+      case TestCase(
+            referencedHistoryRecordingsGroupedById,
+            referringHistoryRecordingsGroupedById,
+            bigShuffledHistoryOverLotsOfThings,
+            asOfs,
+            queryWhen
+          ) =>
+        Using.resource(makeWorld()) { world =>
+          recordEventsInWorld(
+            bigShuffledHistoryOverLotsOfThings,
+            asOfs,
+            world
+          )
+
+          val scope = world.scopeFor(queryWhen, world.nextRevision)
+
+          val checks: List[(Any, History)] =
+            for {
+              referringHistoryRecording <- referringHistoryRecordingsGroupedById
+              RecordingsNoLaterThan(
+                _,
+                referringHistoriesFrom,
+                _,
+                _,
+                _
+              ) <- referringHistoryRecording.thePartNoLaterThan(queryWhen).toList
+              referencedHistoryRecording <-
+                referencedHistoryRecordingsGroupedById
+              NonExistentRecordings(
+                referencedHistoryId,
+                referencedHistoriesFrom,
+                _
+              ) <- referencedHistoryRecording.doesNotExistAt(queryWhen).toList
+              referringHistories = referringHistoriesFrom(scope)
+              if referringHistories.nonEmpty
+              referringHistory =
+                referringHistories.head.asInstanceOf[ReferringHistory]
+              if referringHistory.referencedHistories
+                .get(referencedHistoryId)
+                .exists(!_.asInstanceOf[ItemExtensionApi].isGhost)
+              Seq(referencedHistory) = referencedHistoriesFrom(scope)
+            } yield (referencedHistoryId, referencedHistory)
+
+          for ((_, actualHistory) <- checks) {
+            assert(actualHistory.datums.isEmpty)
+          }
+        }
+    }
+  }
+
+  abstract class NonExistentHistory extends History {
+    override type Id = NonExistentId
+  }
+
+  case class NonExistentId() {
+    throw new RuntimeException(
+      "If I am not supposed to exist, why is something asking for me?"
+    )
+  }
+}

--- a/src/test/scala/com/sageserpent/plutonium/WorldBehaviourAmericium.scala
+++ b/src/test/scala/com/sageserpent/plutonium/WorldBehaviourAmericium.scala
@@ -1,6 +1,8 @@
 package com.sageserpent.plutonium
 
+import com.sageserpent.americium.Trials
 import com.sageserpent.americium.Trials.api
+import com.sageserpent.americium.java.CasesLimitStrategy
 import com.sageserpent.americium.junit5._
 import com.sageserpent.plutonium.World.Revision
 import com.sageserpent.plutonium.utilities.Unbounded
@@ -10,15 +12,6 @@ import _root_.java.time.Instant
 import scala.util.Using
 
 object WorldBehaviourAmericium {
-  object ExpectyFlavouredAssert {
-    import com.eed3si9n.expecty.Expecty
-
-    val assert: Expecty = new Expecty {
-      override val showLocation: Boolean = true
-      override val showTypes: Boolean    = true
-    }
-  }
-
   case class RelatedItemTestCase(
       referencedHistoryRecordingsGroupedById: List[
         WorldSpecSupportAmericium#RecordingsForAnId
@@ -48,8 +41,8 @@ object WorldBehaviourAmericium {
 trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
   this: WorldResourceAmericium =>
 
-  import WorldBehaviourAmericium.ExpectyFlavouredAssert.assert
   import WorldBehaviourAmericium.{HistoryTestCase, RelatedItemTestCase}
+  import ExpectyFlavouredAssert.assert
 
   @TestFactory
   def worldWithNoHistory() = {
@@ -97,7 +90,6 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
         .listsOfSize(bigShuffledHistoryOverLotsOfThings.size)
         .map(_.sorted)
       queryWhen <- unboundedInstantTrials
-      if recordingsGroupedById.exists(_.thePartNoLaterThan(queryWhen).isDefined)
     } yield HistoryTestCase(
       recordingsGroupedById,
       bigShuffledHistoryOverLotsOfThings.map(_.toSeq).toVector,
@@ -132,7 +124,7 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
             Seq(history) = historiesFrom(scope)
           } yield history.datums -> pertinentRecordings.map(_._1)
 
-          assert(checks.nonEmpty)
+          if (checks.isEmpty) Trials.reject()
 
           for ((actualHistory, expectedHistory) <- checks) {
             assert(actualHistory == expectedHistory)
@@ -166,13 +158,6 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
         .listsOfSize(bigShuffledHistoryOverLotsOfThings.size)
         .map(_.sorted)
       queryWhen <- unboundedInstantTrials
-      if (for {
-        referringHistoryRecording <- referringHistoryRecordingsGroupedById
-        _ <- referringHistoryRecording.thePartNoLaterThan(queryWhen).toList
-        referencedHistoryRecording <-
-          referencedHistoryRecordingsGroupedById
-        _ <- referencedHistoryRecording.thePartNoLaterThan(queryWhen).toList
-      } yield ()).nonEmpty
     } yield RelatedItemTestCase(
       referencedHistoryRecordingsGroupedById,
       referringHistoryRecordingsGroupedById,
@@ -180,7 +165,7 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
       asOfs,
       queryWhen
     )
-    testCaseTrials.withLimit(200).dynamicTests {
+    testCaseTrials.withStrategy(_ => CasesLimitStrategy.counted(100, 20)).dynamicTests {
       case RelatedItemTestCase(
             referencedHistoryRecordingsGroupedById,
             referringHistoryRecordingsGroupedById,
@@ -199,23 +184,20 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
 
           val checks =
             for {
-              referringHistoryRecording <- referringHistoryRecordingsGroupedById
               RecordingsNoLaterThan(
                 _,
                 referringHistoriesFrom,
                 _,
                 _,
                 _
-              ) <- referringHistoryRecording.thePartNoLaterThan(queryWhen).toList
-              referencedHistoryRecording <-
-                referencedHistoryRecordingsGroupedById
+              ) <- referringHistoryRecordingsGroupedById.flatMap(_.thePartNoLaterThan(queryWhen))
               RecordingsNoLaterThan(
                 referencedHistoryId,
                 _,
                 pertinentRecordings,
                 _,
                 _
-              ) <- referencedHistoryRecording.thePartNoLaterThan(queryWhen).toList
+              ) <- referencedHistoryRecordingsGroupedById.flatMap(_.thePartNoLaterThan(queryWhen))
               Seq(referringHistory: ReferringHistory) =
                 referringHistoriesFrom(scope)
               if referringHistory.referencedHistories
@@ -225,10 +207,10 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
               referencedHistoryId
             ) -> pertinentRecordings.map(_._1)
 
-          if (checks.nonEmpty) {
-            for ((actualHistory, expectedHistory) <- checks) {
-              assert(actualHistory == expectedHistory)
-            }
+          if (checks.isEmpty) Trials.reject()
+
+          for ((actualHistory, expectedHistory) <- checks) {
+            assert(actualHistory == expectedHistory)
           }
         }
     }
@@ -259,13 +241,6 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
         .listsOfSize(bigShuffledHistoryOverLotsOfThings.size)
         .map(_.sorted)
       queryWhen <- unboundedInstantTrials
-      if (for {
-        referringHistoryRecording <- referringHistoryRecordingsGroupedById
-        _ <- referringHistoryRecording.thePartNoLaterThan(queryWhen).toList
-        referencedHistoryRecording <-
-          referencedHistoryRecordingsGroupedById
-        _ <- referencedHistoryRecording.doesNotExistAt(queryWhen).toList
-      } yield ()).nonEmpty
     } yield RelatedItemTestCase(
       referencedHistoryRecordingsGroupedById,
       referringHistoryRecordingsGroupedById,
@@ -273,7 +248,7 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
       asOfs,
       queryWhen
     )
-    testCaseTrials.withLimit(12).dynamicTests {
+    testCaseTrials.withStrategy(_ => CasesLimitStrategy.counted(100, 20)).dynamicTests {
       case RelatedItemTestCase(
             referencedHistoryRecordingsGroupedById,
             referringHistoryRecordingsGroupedById,
@@ -292,21 +267,18 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
 
           val checks: List[History] =
             for {
-              referringHistoryRecording <- referringHistoryRecordingsGroupedById
               RecordingsNoLaterThan(
                 _,
                 referringHistoriesFrom,
                 _,
                 _,
                 _
-              ) <- referringHistoryRecording.thePartNoLaterThan(queryWhen).toList
-              referencedHistoryRecording <-
-                referencedHistoryRecordingsGroupedById
+              ) <- referringHistoryRecordingsGroupedById.flatMap(_.thePartNoLaterThan(queryWhen))
               NonExistentRecordings(
                 referencedHistoryId,
                 referencedHistoriesFrom,
                 _
-              ) <- referencedHistoryRecording.doesNotExistAt(queryWhen).toList
+              ) <- referencedHistoryRecordingsGroupedById.flatMap(_.doesNotExistAt(queryWhen))
               Seq(referringHistory: ReferringHistory) =
                 referringHistoriesFrom(scope)
               if referringHistory.referencedHistories
@@ -315,10 +287,10 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
               Seq(referencedHistory) = referencedHistoriesFrom(scope)
             } yield referencedHistory
 
-          if (checks.nonEmpty) {
-            for (referencedHistory <- checks) {
-              assert(referencedHistory.datums.isEmpty)
-            }
+          if (checks.isEmpty) Trials.reject()
+
+          for (referencedHistory <- checks) {
+            assert(referencedHistory.datums.isEmpty)
           }
         }
     }

--- a/src/test/scala/com/sageserpent/plutonium/WorldSpecSupportAmericium.scala
+++ b/src/test/scala/com/sageserpent/plutonium/WorldSpecSupportAmericium.scala
@@ -807,17 +807,6 @@ trait WorldSpecSupportAmericium extends Assertions {
         numberOfEventsForLifespans,
         eventWhens
       )
-
-      noAnnihilationsToWorryAbout =
-        finalLifespanIsOngoing && 1 == sampleWhensGroupedForLifespans.size
-
-      firstAnnihilationHasBeenAlignedWithADefiniteWhen =
-        noAnnihilationsToWorryAbout ||
-          PartialFunction.cond(sampleWhensGroupedForLifespans.head.last) {
-            case Finite(_) => true
-          }
-
-      if firstAnnihilationHasBeenAlignedWithADefiniteWhen
     } yield new RecordingsForAPhoenixId(
       historyId,
       historiesFrom,

--- a/src/test/scala/com/sageserpent/plutonium/WorldSpecSupportAmericium.scala
+++ b/src/test/scala/com/sageserpent/plutonium/WorldSpecSupportAmericium.scala
@@ -6,19 +6,24 @@ import com.sageserpent.americium.utilities.seqEnrichment._
 import com.sageserpent.plutonium.World._
 import com.sageserpent.plutonium.efficient.WorldEfficientInMemoryImplementation
 import com.sageserpent.plutonium.reference.WorldReferenceImplementation
-import com.sageserpent.plutonium.utilities.{
-  Finite,
-  NegativeInfinity,
-  PositiveInfinity,
-  Unbounded
-}
-import org.scalatest.Assertions
+import com.sageserpent.plutonium.utilities.{Finite, NegativeInfinity, PositiveInfinity, Unbounded}
 
 import java.time.Instant
 import scala.collection.Searching._
 import scala.collection.immutable.TreeMap
 import scala.language.postfixOps
 import scala.reflect.runtime.universe.{Scope => _, _}
+import ExpectyFlavouredAssert.assert
+import org.junit.jupiter.api.Assertions.assertThrows
+
+object ExpectyFlavouredAssert {
+  import com.eed3si9n.expecty.Expecty
+
+  val assert: Expecty = new Expecty {
+    override val showLocation: Boolean = true
+    override val showTypes: Boolean    = true
+  }
+}
 
 object WorldSpecSupportAmericium {
   val changeError = new RuntimeException("Error in making a change.")
@@ -28,7 +33,7 @@ object WorldSpecSupportAmericium {
   }
 }
 
-trait WorldSpecSupportAmericium extends Assertions {
+trait WorldSpecSupportAmericium {
 
   import WorldSpecSupportAmericium._
 
@@ -125,14 +130,14 @@ trait WorldSpecSupportAmericium extends Assertions {
                   referringHistory
                     .forceInvariantBreakage() // Modelling breakage of the bitemporal invariant.
 
-                assertThrows[UnsupportedOperationException](
-                  referringHistory.datums
+                assertThrows(classOf[UnsupportedOperationException],
+                  () => referringHistory.datums
                 )
-                assertThrows[UnsupportedOperationException](
-                  referringHistory.referencedDatums
+                assertThrows(classOf[UnsupportedOperationException],
+                  () => referringHistory.referencedDatums
                 )
-                assertThrows[UnsupportedOperationException](
-                  referringHistory.referencedHistories
+                assertThrows(classOf[UnsupportedOperationException],
+                  () => referringHistory.referencedHistories
                 )
 
                 referringHistory.referTo(referencedItem)
@@ -168,14 +173,15 @@ trait WorldSpecSupportAmericium extends Assertions {
             (referringHistory: ReferringHistory, referencedItem: FooHistory) =>
               {
                 assert(referringHistoryId == referringHistory.id)
-                assertThrows[UnsupportedOperationException](
-                  referringHistory.datums
+
+                assertThrows(classOf[UnsupportedOperationException],
+                  () => referringHistory.datums
                 )
-                assertThrows[UnsupportedOperationException](
-                  referringHistory.referencedDatums
+                assertThrows(classOf[UnsupportedOperationException],
+                  () => referringHistory.referencedDatums
                 )
-                assertThrows[UnsupportedOperationException](
-                  referringHistory.referencedHistories
+                assertThrows(classOf[UnsupportedOperationException],
+                  () => referringHistory.referencedHistories
                 )
 
                 if (faulty)
@@ -408,13 +414,9 @@ trait WorldSpecSupportAmericium extends Assertions {
                 // Changes are not allowed to read from the items they work on,
                 // with the exception of the 'id' property.
                 assert(fooHistoryId == fooHistory.id)
-                assertThrows[UnsupportedOperationException](fooHistory.datums)
-                assertThrows[UnsupportedOperationException](
-                  fooHistory.property1
-                )
-                assertThrows[UnsupportedOperationException](
-                  fooHistory.property2
-                )
+                assertThrows(classOf[UnsupportedOperationException], () => fooHistory.datums)
+                assertThrows(classOf[UnsupportedOperationException], () => fooHistory.property1)
+                assertThrows(classOf[UnsupportedOperationException], () => fooHistory.property2)
 
                 fooHistory.property1 = data
               }
@@ -427,13 +429,9 @@ trait WorldSpecSupportAmericium extends Assertions {
                 // Changes are not allowed to read from the items they work on,
                 // with the exception of the 'id' property.
                 assert(fooHistoryId == fooHistory.id)
-                assertThrows[UnsupportedOperationException](fooHistory.datums)
-                assertThrows[UnsupportedOperationException](
-                  fooHistory.property1
-                )
-                assertThrows[UnsupportedOperationException](
-                  fooHistory.property2
-                )
+                assertThrows(classOf[UnsupportedOperationException], () => fooHistory.datums)
+                assertThrows(classOf[UnsupportedOperationException], () => fooHistory.property1)
+                assertThrows(classOf[UnsupportedOperationException], () => fooHistory.property2)
 
                 fooHistory.property1 = data
               }
@@ -454,13 +452,9 @@ trait WorldSpecSupportAmericium extends Assertions {
                 // Changes are not allowed to read from the items they work on,
                 // with the exception of the 'id' property.
                 assert(fooHistoryId == fooHistory.id)
-                assertThrows[UnsupportedOperationException](fooHistory.datums)
-                assertThrows[UnsupportedOperationException](
-                  fooHistory.property1
-                )
-                assertThrows[UnsupportedOperationException](
-                  fooHistory.property2
-                )
+                assertThrows(classOf[UnsupportedOperationException], () => fooHistory.datums)
+                assertThrows(classOf[UnsupportedOperationException], () => fooHistory.property1)
+                assertThrows(classOf[UnsupportedOperationException], () => fooHistory.property2)
 
                 fooHistory.property2 = data
               }
@@ -473,13 +467,9 @@ trait WorldSpecSupportAmericium extends Assertions {
                 // Changes are not allowed to read from the items they work on,
                 // with the exception of the 'id' property.
                 assert(fooHistoryId == fooHistory.id)
-                assertThrows[UnsupportedOperationException](fooHistory.datums)
-                assertThrows[UnsupportedOperationException](
-                  fooHistory.property1
-                )
-                assertThrows[UnsupportedOperationException](
-                  fooHistory.property2
-                )
+                assertThrows(classOf[UnsupportedOperationException], () => fooHistory.datums)
+                assertThrows(classOf[UnsupportedOperationException], () => fooHistory.property1)
+                assertThrows(classOf[UnsupportedOperationException], () => fooHistory.property2)
 
                 fooHistory.property2 = data
               }
@@ -502,9 +492,9 @@ trait WorldSpecSupportAmericium extends Assertions {
               // Changes are not allowed to read from the items they work on,
               // with the exception of the 'id' property.
               assert(fooHistoryId == fooHistory.id)
-              assertThrows[UnsupportedOperationException](fooHistory.datums)
-              assertThrows[UnsupportedOperationException](fooHistory.property1)
-              assertThrows[UnsupportedOperationException](fooHistory.property2)
+              assertThrows(classOf[UnsupportedOperationException], () => fooHistory.datums)
+              assertThrows(classOf[UnsupportedOperationException], () => fooHistory.property1)
+              assertThrows(classOf[UnsupportedOperationException], () => fooHistory.property2)
 
               fooHistory.property1 = data
 
@@ -555,8 +545,8 @@ trait WorldSpecSupportAmericium extends Assertions {
               // Changes are not allowed to read from the items they work on,
               // with the exception of the 'id' property.
               assert(barHistory.id == barHistoryId)
-              assertThrows[UnsupportedOperationException](barHistory.datums)
-              assertThrows[UnsupportedOperationException](barHistory.property1)
+              assertThrows(classOf[UnsupportedOperationException], () => barHistory.datums)
+              assertThrows(classOf[UnsupportedOperationException], () => barHistory.property1)
 
               barHistory.property1 = data
             }
@@ -579,8 +569,8 @@ trait WorldSpecSupportAmericium extends Assertions {
               // Changes are not allowed to read from the items they work on,
               // with the exception of the 'id' property.
               assert(barHistory.id == barHistoryId)
-              assertThrows[UnsupportedOperationException](barHistory.datums)
-              assertThrows[UnsupportedOperationException](barHistory.property1)
+              assertThrows(classOf[UnsupportedOperationException], () => barHistory.datums)
+              assertThrows(classOf[UnsupportedOperationException], () => barHistory.property1)
 
               barHistory.method1(data1, data2)
 
@@ -608,8 +598,8 @@ trait WorldSpecSupportAmericium extends Assertions {
               // Changes are not allowed to read from the items they work on,
               // with the exception of the 'id' property.
               assert(barHistory.id == barHistoryId)
-              assertThrows[UnsupportedOperationException](barHistory.datums)
-              assertThrows[UnsupportedOperationException](barHistory.property1)
+              assertThrows(classOf[UnsupportedOperationException], () => barHistory.datums)
+              assertThrows(classOf[UnsupportedOperationException], () => barHistory.property1)
 
               barHistory.method2(data1, data2, data3)
 
@@ -636,10 +626,8 @@ trait WorldSpecSupportAmericium extends Assertions {
               // Changes are not allowed to read from the items they work on,
               // with the exception of the 'id' property.
               assert(integerHistoryId == integerHistory.id)
-              assertThrows[UnsupportedOperationException](integerHistory.datums)
-              assertThrows[UnsupportedOperationException](
-                integerHistory.integerProperty
-              )
+              assertThrows(classOf[UnsupportedOperationException], () => integerHistory.datums)
+              assertThrows(classOf[UnsupportedOperationException], () => integerHistory.integerProperty)
 
               if (faulty)
                 integerHistory

--- a/src/test/scala/com/sageserpent/plutonium/WorldSpecSupportAmericium.scala
+++ b/src/test/scala/com/sageserpent/plutonium/WorldSpecSupportAmericium.scala
@@ -38,6 +38,19 @@ trait WorldSpecSupportAmericium extends Assertions {
 
   def instantTrials: Trials[Instant] = api.instants
 
+  def unboundedInstantTrials: Trials[Unbounded[Instant]] =
+    api.alternateWithWeights(
+      1  -> api.only(NegativeInfinity),
+      1  -> api.only(PositiveInfinity),
+      10 -> instantTrials.map(Finite.apply[Instant])
+    )
+
+  def changeWhenTrials: Trials[Unbounded[Instant]] =
+    api.alternateWithWeights(
+      1  -> api.only(NegativeInfinity),
+      10 -> instantTrials.map(Finite.apply[Instant])
+    )
+
   def stringIdTrials: Trials[String] =
     api.uniqueIds.map("Name: " + _.toString)
 
@@ -794,6 +807,17 @@ trait WorldSpecSupportAmericium extends Assertions {
         numberOfEventsForLifespans,
         eventWhens
       )
+
+      noAnnihilationsToWorryAbout =
+        finalLifespanIsOngoing && 1 == sampleWhensGroupedForLifespans.size
+
+      firstAnnihilationHasBeenAlignedWithADefiniteWhen =
+        noAnnihilationsToWorryAbout ||
+          PartialFunction.cond(sampleWhensGroupedForLifespans.head.last) {
+            case Finite(_) => true
+          }
+
+      if firstAnnihilationHasBeenAlignedWithADefiniteWhen
     } yield new RecordingsForAPhoenixId(
       historyId,
       historiesFrom,

--- a/src/test/scala/com/sageserpent/plutonium/efficient/WorldSpecUsingWorldEfficientInMemoryImplementationAmericium.scala
+++ b/src/test/scala/com/sageserpent/plutonium/efficient/WorldSpecUsingWorldEfficientInMemoryImplementationAmericium.scala
@@ -1,0 +1,7 @@
+package com.sageserpent.plutonium.efficient
+
+import com.sageserpent.plutonium.{WorldBehaviourAmericium, WorldEfficientInMemoryImplementationResourceAmericium}
+
+class WorldSpecUsingWorldEfficientInMemoryImplementationAmericium
+    extends WorldBehaviourAmericium
+    with WorldEfficientInMemoryImplementationResourceAmericium

--- a/src/test/scala/com/sageserpent/plutonium/reference/WorldSpecUsingWorldReferenceImplementationAmericium.scala
+++ b/src/test/scala/com/sageserpent/plutonium/reference/WorldSpecUsingWorldReferenceImplementationAmericium.scala
@@ -1,0 +1,7 @@
+package com.sageserpent.plutonium.reference
+
+import com.sageserpent.plutonium.{WorldBehaviourAmericium, WorldReferenceImplementationResourceAmericium}
+
+class WorldSpecUsingWorldReferenceImplementationAmericium
+    extends WorldBehaviourAmericium
+    with WorldReferenceImplementationResourceAmericium


### PR DESCRIPTION
Ported specific tests from `WorldBehaviours.scala` to a new JUnit 5/Americium-based suite (`WorldBehaviourAmericium.scala`). This includes core infrastructure tests and the two complex relationship tests requested. The new suite uses `Americium` for property-based generation, `JUnit 5` for test execution, and `Expecty` for assertions. It also integrates `intersperseObsoleteEventsAmericium` to verify world behavior against corrected histories. Matching subclasses for competing World implementations have been created in their respective packages.

---
*PR created automatically by Jules for task [9369782283384320943](https://jules.google.com/task/9369782283384320943) started by @sageserpent-open*