### PR TITLE
Port 'reveal the same history from a scope with an asOf limit...' and reordered existing tests.

### DIFF
--- a/src/test/scala/com/sageserpent/plutonium/WorldBehaviourAmericium.scala
+++ b/src/test/scala/com/sageserpent/plutonium/WorldBehaviourAmericium.scala
@@ -960,6 +960,55 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
   }
 
 @TestFactory
+  def buildAnItemsStateInAMannerConsistentWithTheHistoryExperiencedByTheItemDueToEventsThatDefineChangesOnIt()
+      : DynamicTests = {
+    val itemId = "Fred"
+
+    val testCaseTrials = for {
+      eventTimes <- instantTrials.nonEmptyLists.map(_.sorted)
+      sequence = 1 to eventTimes.size
+      events: List[(Unbounded[Instant], Event)] =
+        eventTimes.zip(sequence).map { case (when, step) =>
+          Finite(when) -> Change
+            .forOneItem[StrictlyIncreasingSequenceConsumer](when)(
+              itemId,
+              { item: StrictlyIncreasingSequenceConsumer =>
+                item.consume(step)
+              }
+            )
+        }
+      bigShuffledHistoryOverLotsOfThings <-
+        shuffleRecordingsPreservingRelativeOrderOfEventsAtTheSameWhenForAGivenItem(
+          events
+        ).flatMap(shuffled => api.splitsIntoNonEmptyPieces(shuffled.zipWithIndex)).map(liftRecordings)
+      asOfs <- instantTrials
+        .listsOfSize(bigShuffledHistoryOverLotsOfThings.size)
+        .map(_.sorted)
+      queryWhen <- unboundedInstantTrials
+    } yield (bigShuffledHistoryOverLotsOfThings, asOfs, queryWhen)
+
+    testCaseTrials.withLimit(200).dynamicTests {
+      case (bigShuffledHistoryOverLotsOfThings, asOfs, queryWhen) =>
+        Using.resource(makeWorld()) { world =>
+          recordEventsInWorld(
+            bigShuffledHistoryOverLotsOfThings,
+            asOfs,
+            world
+          )
+
+          val scope = world.scopeFor(queryWhen, world.nextRevision)
+
+          val _ = scope
+            .render(
+              Bitemporal
+                .withId[StrictlyIncreasingSequenceConsumer](itemId)
+            )
+            .toList
+        }
+    }
+  }
+
+@TestFactory
   def revealAllTheHistoryOfARelatedItemUpToTheWhenLimitOfAScopeMadeFromIt(): DynamicTests = {
     val testCaseTrials = for {
       referencedHistoryRecordingsGroupedById <-
@@ -2843,6 +2892,8 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
         }
     }
   }
+
+
 
 
 

--- a/src/test/scala/com/sageserpent/plutonium/WorldBehaviourAmericium.scala
+++ b/src/test/scala/com/sageserpent/plutonium/WorldBehaviourAmericium.scala
@@ -4254,7 +4254,7 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
                     asOfs
                   ) :: remainingSubsections =>
                 val sortedEventIds =
-                  bigShuffledHistoryOverLotsOfThings.flatMap(_.map(_._2)).sorted.distinct
+                  (bigShuffledHistoryOverLotsOfThings.flatMap(_.map(_._2))).sorted.distinct
                 assert(0 == sortedEventIds.head)
                 assert((sortedEventIds zip sortedEventIds.tail).forall {
                   case (first, second) => 1 + first == second
@@ -4269,11 +4269,17 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
                   )
                 val asOfForAnnulments = asOfs.head
                 try {
+                  if (world.revisionAsOfs.nonEmpty && asOfForAnnulments.isBefore(world.revisionAsOfs.last)) {
+                    throw new RuntimeException("Inconsistent asOf for annulments")
+                  }
                   recordEventsInWorld(
                     annulmentsForExtraEventIdsNotCorrectedInThisSubsection,
                     List(asOfForAnnulments),
                     world
                   )
+                  if (asOfs.nonEmpty && asOfs.head.isBefore(world.revisionAsOfs.last)) {
+                    throw new RuntimeException("Inconsistent asOf for history")
+                  }
                   recordEventsInWorld(
                     bigShuffledHistoryOverLotsOfThings,
                     asOfs.toList,

--- a/src/test/scala/com/sageserpent/plutonium/WorldBehaviourAmericium.scala
+++ b/src/test/scala/com/sageserpent/plutonium/WorldBehaviourAmericium.scala
@@ -769,6 +769,88 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
   }
 
 @TestFactory
+  def revealTheSameNextRevisionFromAScopeWithAnAsOfLimitThatComesAtOrAfterThatRevisionButBeforeTheFollowingRevision()
+      : DynamicTests = {
+    val testCaseTrials = for {
+      recordingsGroupedById <- recordingsGroupedByIdTrials(
+        forbidAnnihilations = false
+      )
+      shuffledRecordings <-
+        shuffleRecordingsPreservingRelativeOrderOfEventsAtTheSameWhen(
+          recordingsGroupedById
+        )
+      bigShuffledHistoryOverLotsOfThings <- api
+        .splitsIntoNonEmptyPieces(shuffledRecordings.zipWithIndex)
+        .map(liftRecordings)
+      asOfs <- instantTrials
+        .listsOfSize(bigShuffledHistoryOverLotsOfThings.size)
+        .map(_.sorted)
+      queryWhen <- unboundedInstantTrials
+      laterAsOfs <- api.sequences(asOfs.zip(asOfs.tail :+ asOfs.last.plusSeconds(10L)).map {
+        case (earlier, later) if earlier isBefore later =>
+          api.longs(earlier.getEpochSecond, later.getEpochSecond - 1).map(Instant.ofEpochSecond).filter(_ isAfter earlier)
+        case (earlier, _) => api.only(earlier)
+      })
+    } yield NextRevisionConsistencyTestCase(
+      recordingsGroupedById,
+      bigShuffledHistoryOverLotsOfThings,
+      asOfs,
+      queryWhen,
+      laterAsOfs
+    )
+
+    testCaseTrials.withLimit(200).dynamicTests {
+      case NextRevisionConsistencyTestCase(
+            _,
+            bigShuffledHistoryOverLotsOfThings,
+            asOfs,
+            queryWhen,
+            laterAsOfs
+          ) =>
+        Using.resource(makeWorld()) { world =>
+          val revisions = recordEventsInWorld(
+            bigShuffledHistoryOverLotsOfThings,
+            asOfs,
+            world
+          )
+
+          val checks = for {
+            (
+              (earlierAsOfCorrespondingToRevision, revision),
+              laterAsOfSharingTheSameRevisionAsTheEarlierOne
+            ) <- asOfs zip revisions zip laterAsOfs
+            if earlierAsOfCorrespondingToRevision isBefore laterAsOfSharingTheSameRevisionAsTheEarlierOne
+
+            baselineScope = world
+              .scopeFor(queryWhen, earlierAsOfCorrespondingToRevision)
+            scopeForLaterAsOfSharingTheSameRevisionAsTheEarlierOne =
+              world
+                .scopeFor(
+                  queryWhen,
+                  laterAsOfSharingTheSameRevisionAsTheEarlierOne
+                )
+          } yield (
+            baselineScope,
+            scopeForLaterAsOfSharingTheSameRevisionAsTheEarlierOne
+          )
+
+          if (checks.isEmpty) Trials.reject()
+
+          for (
+            (
+              baselineScope,
+              scopeForLaterAsOfSharingTheSameRevisionAsTheEarlierOne
+            ) <- checks
+          ) {
+            assert(
+              baselineScope.nextRevision == scopeForLaterAsOfSharingTheSameRevisionAsTheEarlierOne.nextRevision
+            )
+          }
+        }
+    }
+  }
+
+@TestFactory
   def revealAllTheHistoryUpToTheWhenLimitOfAScopeMadeFromIt(): DynamicTests = {
     val testCaseTrials = for {
       recordingsGroupedById <- recordingsGroupedByIdTrials(
@@ -2721,6 +2803,8 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
         }
     }
   }
+
+
 
 
 

--- a/src/test/scala/com/sageserpent/plutonium/WorldBehaviourAmericium.scala
+++ b/src/test/scala/com/sageserpent/plutonium/WorldBehaviourAmericium.scala
@@ -1009,6 +1009,68 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
   }
 
 @TestFactory
+  def allowAnItemToBeRenderedFromABitemporalIfTheWhenLimitOfTheScopeIncludesARelevantEventThatDefinesSaidItem()
+      : DynamicTests = {
+    val testCaseTrials = for {
+      recordingsGroupedById <- recordingsGroupedByIdTrials(
+        forbidAnnihilations = false
+      )
+      shuffledRecordings <-
+        shuffleRecordingsPreservingRelativeOrderOfEventsAtTheSameWhen(
+          recordingsGroupedById
+        )
+      bigShuffledHistoryOverLotsOfThings <- api
+        .splitsIntoNonEmptyPieces(shuffledRecordings.zipWithIndex)
+        .map(liftRecordings)
+      asOfs <- instantTrials
+        .listsOfSize(bigShuffledHistoryOverLotsOfThings.size)
+        .map(_.sorted)
+      queryWhen <- unboundedInstantTrials
+    } yield HistoryTestCase(
+      recordingsGroupedById,
+      bigShuffledHistoryOverLotsOfThings,
+      asOfs,
+      queryWhen
+    )
+
+    testCaseTrials.withLimit(200).dynamicTests {
+      case HistoryTestCase(
+            recordingsGroupedById,
+            bigShuffledHistoryOverLotsOfThings,
+            asOfs,
+            queryWhen
+          ) =>
+        Using.resource(makeWorld()) { world =>
+          recordEventsInWorld(
+            bigShuffledHistoryOverLotsOfThings,
+            asOfs,
+            world
+          )
+
+          val scope = world.scopeFor(queryWhen, world.nextRevision)
+
+          val checks = for {
+            recording <- recordingsGroupedById
+            RecordingsNoLaterThan(historyId, historiesFrom, _, _, _) <-
+              recording.thePartNoLaterThan(
+                queryWhen
+              )
+          } yield (historiesFrom, historyId)
+
+          if (checks.isEmpty) Trials.reject()
+
+          for ((historiesFrom, historyId) <- checks) {
+            withClue(s"Could not find a history for id: $historyId.") {
+              assert(historiesFrom(scope) match {
+                case Seq(_) => true
+              })
+            }
+          }
+        }
+    }
+  }
+
+@TestFactory
   def revealAllTheHistoryOfARelatedItemUpToTheWhenLimitOfAScopeMadeFromIt(): DynamicTests = {
     val testCaseTrials = for {
       referencedHistoryRecordingsGroupedById <-
@@ -2892,6 +2954,8 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
         }
     }
   }
+
+
 
 
 

--- a/src/test/scala/com/sageserpent/plutonium/WorldBehaviourAmericium.scala
+++ b/src/test/scala/com/sageserpent/plutonium/WorldBehaviourAmericium.scala
@@ -309,6 +309,21 @@ object WorldBehaviourAmericium {
       queryWhen: Unbounded[Instant]
   )
 
+  case class VersionReflectionTestCase(
+      recordingsGroupedById: Seq[WorldSpecSupportAmericium#RecordingsForAnId],
+      bigOverallShuffledHistoryOverLotsOfThings: Seq[
+        Seq[
+          (
+              Option[(Unbounded[Instant], Event)],
+              intersperseObsoleteEventsAmericium.EventId
+          )
+        ]
+      ],
+      asOfs: Seq[Instant],
+      queryWhen: Unbounded[Instant],
+      revisionOffsetToCheckAt: Int
+  )
+
   case class AnnulledAnnihilationTestCase(
       bigShuffledHistoryOverLotsOfThings: Seq[
         Seq[
@@ -4028,6 +4043,104 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
         }
     }
   }
+
+@TestFactory
+  def yieldAHistoryWhoseVersionsOfEventsReflectTheRevisionOfAScopeMadeFromIt(): DynamicTests = {
+    val testCaseTrials = for {
+      recordingsGroupedById <- recordingsGroupedByIdTrials(
+        forbidAnnihilations = true
+      )
+      obsoleteRecordingsGroupedById <-
+        nonConflictingRecordingsGroupedByIdTrials
+      followingRecordingsGroupedById <-
+        nonConflictingRecordingsGroupedByIdTrials
+      shuffledRecordings <-
+        shuffleRecordingsPreservingRelativeOrderOfEventsAtTheSameWhen(
+          recordingsGroupedById
+        )
+      shuffledObsoleteRecordings <-
+        shuffleRecordingsPreservingRelativeOrderOfEventsAtTheSameWhen(
+          obsoleteRecordingsGroupedById
+        )
+      bigShuffledHistoryOverLotsOfThings <- intersperseObsoleteEventsAmericium(
+        shuffledRecordings,
+        shuffledObsoleteRecordings
+      )
+      shuffledFollowingRecordingAndEventPairs <-
+        shuffleRecordingsPreservingRelativeOrderOfEventsAtTheSameWhen(
+          followingRecordingsGroupedById
+        ).map(_.zipWithIndex)
+      bigFollowingShuffledHistoryOverLotsOfThings <- api
+        .splitsIntoNonEmptyPieces(shuffledFollowingRecordingAndEventPairs)
+        .map(liftRecordings)
+      bigOverallShuffledHistoryOverLotsOfThings =
+        bigShuffledHistoryOverLotsOfThings ++ bigFollowingShuffledHistoryOverLotsOfThings
+      asOfs <- instantTrials
+        .listsOfSize(bigOverallShuffledHistoryOverLotsOfThings.length)
+        .map(_.sorted)
+      queryWhen <- unboundedInstantTrials
+      revisionOffsetToCheckAt <- api.only(
+        bigShuffledHistoryOverLotsOfThings.length
+      )
+    } yield VersionReflectionTestCase(
+      recordingsGroupedById,
+      bigOverallShuffledHistoryOverLotsOfThings,
+      asOfs,
+      queryWhen,
+      revisionOffsetToCheckAt
+    )
+
+    testCaseTrials.withLimit(200).dynamicTests {
+      case VersionReflectionTestCase(
+            recordingsGroupedById,
+            bigOverallShuffledHistoryOverLotsOfThings,
+            asOfs,
+            queryWhen,
+            revisionOffsetToCheckAt
+          ) =>
+        Using.resource(makeWorld()) { world =>
+          recordEventsInWorld(
+            bigOverallShuffledHistoryOverLotsOfThings,
+            asOfs,
+            world
+          )
+
+          val scope =
+            world.scopeFor(
+              queryWhen,
+              World.initialRevision + revisionOffsetToCheckAt
+            )
+
+          val checks = for {
+            recording <- recordingsGroupedById
+            RecordingsNoLaterThan(
+              historyId,
+              historiesFrom,
+              pertinentRecordings,
+              _,
+              _
+            ) <- recording.thePartNoLaterThan(
+              queryWhen
+            )
+            Seq(history) = historiesFrom(scope)
+          } yield (
+            historyId,
+            history.datums,
+            pertinentRecordings.map(_._1)
+          )
+
+          if (checks.isEmpty) Trials.reject()
+
+          for ((historyId, actualHistory, expectedHistory) <- checks) {
+            withClue(s"History mismatch for history id: $historyId.") {
+              assert(actualHistory == expectedHistory)
+            }
+          }
+        }
+    }
+  }
+
+
 
 
 

--- a/src/test/scala/com/sageserpent/plutonium/WorldBehaviourAmericium.scala
+++ b/src/test/scala/com/sageserpent/plutonium/WorldBehaviourAmericium.scala
@@ -3273,6 +3273,234 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
   }
 
 @TestFactory
+  def takeIntoAccountThePreciseTypeOfTheItemReferencedByAnAnnihilationWhenOtherEventsReferToTheSameItemViaLooserTypes()
+      : DynamicTests = {
+    val testCaseTrials: Trials[PreciseTypeAnnihilationTestCase] = for {
+      recordingsGroupedById <- mixedAbstractedAndImplementingRecordingsGroupedByIdTrials(
+        forbidAnnihilations = true
+      )
+      obsoleteRecordingsGroupedById <-
+        nonConflictingRecordingsGroupedByIdTrials
+      shuffledRecordings <-
+        shuffleRecordingsPreservingRelativeOrderOfEventsAtTheSameWhen(
+          recordingsGroupedById
+        )
+      shuffledObsoleteRecordings <-
+        shuffleRecordingsPreservingRelativeOrderOfEventsAtTheSameWhen(
+          obsoleteRecordingsGroupedById
+        )
+      bigShuffledHistoryOverLotsOfThings <- intersperseObsoleteEventsAmericium(
+        shuffledRecordings,
+        shuffledObsoleteRecordings
+      )
+      asOfs <- instantTrials
+        .listsOfSize(bigShuffledHistoryOverLotsOfThings.size)
+        .map(_.sorted)
+      annihilationWhen <- instantTrials
+      queryWhenLeadsAnnihilationBy <- api.integers(1, 1000000)
+    } yield PreciseTypeAnnihilationTestCase(
+      recordingsGroupedById,
+      bigShuffledHistoryOverLotsOfThings,
+      asOfs,
+      annihilationWhen,
+      annihilationWhen.minusMillis(queryWhenLeadsAnnihilationBy.toLong)
+    )
+
+    testCaseTrials.withLimit(200).dynamicTests {
+      case PreciseTypeAnnihilationTestCase(
+            recordingsGroupedById,
+            bigShuffledHistoryOverLotsOfThings,
+            asOfs,
+            whenAnnihilationOccurs,
+            queryWhen
+          ) =>
+        Using.resource(makeWorld()) { world =>
+          try {
+            recordEventsInWorld(
+              bigShuffledHistoryOverLotsOfThings,
+              asOfs,
+              world
+            )
+
+            for {
+              (recording, eventIdForAnnihilation) <- recordingsGroupedById
+                .flatMap(_.thePartNoLaterThan(Finite(queryWhen)))
+                .zip(LazyList.from(-1, -1))
+            } {
+              world.revise(
+                eventIdForAnnihilation,
+                Annihilation[NegatingImplementingHistory](
+                  whenAnnihilationOccurs,
+                  recording.historyId.asInstanceOf[String]
+                ),
+                world.revisionAsOfs.last
+              )
+            }
+
+            val scopeThatShouldPickOutNegatingImplementingHistories =
+              world.scopeFor(Finite(queryWhen), world.nextRevision)
+
+            for {
+              (recording, eventIdForAnnihilation) <- recordingsGroupedById
+                .flatMap(_.thePartNoLaterThan(Finite(queryWhen)))
+                .zip(LazyList.from(-1, -1))
+            } {
+              world.revise(
+                eventIdForAnnihilation,
+                Annihilation[ImplementingHistory](
+                  whenAnnihilationOccurs,
+                  recording.historyId.asInstanceOf[String]
+                ),
+                world.revisionAsOfs.last
+              )
+            }
+
+            val scopeThatShouldPickOutImplementingHistories =
+              world.scopeFor(Finite(queryWhen), world.nextRevision)
+
+            val checks =
+              for {
+                recording <- recordingsGroupedById
+                RecordingsNoLaterThan(
+                  historyId,
+                  historiesFrom,
+                  _,
+                  _,
+                  _
+                ) <-
+                  recording.thePartNoLaterThan(
+                    Finite(queryWhen)
+                  )
+                Seq(negatedHistory) = historiesFrom(
+                  scopeThatShouldPickOutNegatingImplementingHistories
+                )
+                Seq(history) = historiesFrom(
+                  scopeThatShouldPickOutImplementingHistories
+                )
+              } yield (historyId, negatedHistory.datums, history.datums)
+
+            if (checks.isEmpty) Trials.reject()
+
+            for ((historyId, negatedHistory, expectedHistory) <- checks) {
+              withClue(s"For history id: $historyId.") {
+                assert(negatedHistory.length == expectedHistory.length)
+                for ((actual, expected) <- negatedHistory zip expectedHistory) {
+                  val negatedExpectedValue =
+                    -expected.asInstanceOf[Int]
+                  assert(actual == negatedExpectedValue)
+                }
+              }
+            }
+          } catch {
+            case _: UnsupportedOperationException => Trials.reject()
+          }
+        }
+    }
+  }
+
+@TestFactory
+  def reflectTheAbsenceOfAllItemsOfACompatibleTypeRelevantToAScopeThatShareAnIdFollowingAnAnnihilationUsingThatId()
+      : DynamicTests = {
+    val testCaseTrials = for {
+      recordingsGroupedById <- recordingsGroupedByIdTrials(
+        forbidAnnihilations = true
+      )
+      queryWhen <- instantTrials
+      possiblyEmptySetOfIdsThatEachReferToMoreThanOneItem =
+        ((recordingsGroupedById.flatMap(_.thePartNoLaterThan(
+          Finite(queryWhen)
+        )) map (_.historyId)) groupBy identity collect {
+          case (id, group) if 1 < group.size => id
+        }).toSet
+      if possiblyEmptySetOfIdsThatEachReferToMoreThanOneItem.nonEmpty
+      idsThatEachReferToMoreThanOneItem <- api.only(
+        possiblyEmptySetOfIdsThatEachReferToMoreThanOneItem
+      )
+      obsoleteRecordingsGroupedById <-
+        nonConflictingRecordingsGroupedByIdTrials
+      shuffledRecordings <-
+        shuffleRecordingsPreservingRelativeOrderOfEventsAtTheSameWhen(
+          recordingsGroupedById
+        )
+      shuffledObsoleteRecordings <-
+        shuffleRecordingsPreservingRelativeOrderOfEventsAtTheSameWhen(
+          obsoleteRecordingsGroupedById
+        )
+      bigShuffledHistoryOverLotsOfThings <- intersperseObsoleteEventsAmericium(
+        shuffledRecordings,
+        shuffledObsoleteRecordings
+      )
+      asOfs <- instantTrials
+        .listsOfSize(bigShuffledHistoryOverLotsOfThings.size)
+        .map(_.sorted)
+    } yield AbsenceFollowingAnnihilationTestCase(
+      recordingsGroupedById,
+      bigShuffledHistoryOverLotsOfThings,
+      asOfs,
+      queryWhen
+    )
+
+    testCaseTrials.withLimit(200).dynamicTests {
+      case AbsenceFollowingAnnihilationTestCase(
+            recordingsGroupedById,
+            bigShuffledHistoryOverLotsOfThings,
+            asOfs,
+            queryWhen
+          ) =>
+        Using.resource(makeWorld()) { world =>
+          recordEventsInWorld(
+            bigShuffledHistoryOverLotsOfThings,
+            asOfs,
+            world
+          )
+
+          val idsThatEachReferToMoreThanOneItem =
+            ((recordingsGroupedById.flatMap(_.thePartNoLaterThan(
+              Finite(queryWhen)
+            )) map (_.historyId)) groupBy identity collect {
+              case (id, group) if 1 < group.size => id
+            }).toSet
+
+          val maximumEventId =
+            bigShuffledHistoryOverLotsOfThings.flatten map (_._2) max
+
+          val annihilationEvents =
+            idsThatEachReferToMoreThanOneItem.zipWithIndex map {
+              case (idThatEachRefersToMoreThanOneItem, index) =>
+                (
+                  1 + maximumEventId + index,
+                  Some(
+                    Annihilation[History](
+                      queryWhen,
+                      idThatEachRefersToMoreThanOneItem
+                        .asInstanceOf[History#Id]
+                    )
+                  )
+                )
+            } toMap
+
+          world.revise(annihilationEvents, asOfs.last)
+
+          val scope =
+            world.scopeFor(Finite(queryWhen), world.nextRevision)
+
+          for (id <- idsThatEachReferToMoreThanOneItem) {
+            val itemsThatShouldNotExist = scope
+              .render(
+                Bitemporal.withId[History](id.asInstanceOf[History#Id])
+              )
+              .toList
+            withClue(
+              s"The items '$itemsThatShouldNotExist' for id: '$id' should not exist at the query time of: '$queryWhen'."
+            ) {
+              assert(itemsThatShouldNotExist.isEmpty)
+            }
+          }
+        }
+    }
+  }
+
+@TestFactory
   def extendTheHistoryOfAnItemWhoseAnnihilationIsAnnulledToPickUpAnySubsequentEventsRelatingToThatItem()
       : DynamicTests = {
     val itemId = "Fred"
@@ -3585,6 +3813,88 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
         }
     }
   }
+
+@TestFactory
+  def yieldAHistoryAtTheFinalRevisionBasedOnlyOnTheLatestCorrections(): DynamicTests = {
+    val testCaseTrials = for {
+      recordingsGroupedById <- recordingsGroupedByIdTrials(
+        forbidAnnihilations = false
+      )
+      obsoleteRecordingsGroupedById <-
+        nonConflictingRecordingsGroupedByIdTrials
+      shuffledRecordings <-
+        shuffleRecordingsPreservingRelativeOrderOfEventsAtTheSameWhen(
+          recordingsGroupedById
+        )
+      shuffledObsoleteRecordings <-
+        shuffleRecordingsPreservingRelativeOrderOfEventsAtTheSameWhen(
+          obsoleteRecordingsGroupedById
+        )
+      bigShuffledHistoryOverLotsOfThings <- intersperseObsoleteEventsAmericium(
+        shuffledRecordings,
+        shuffledObsoleteRecordings
+      )
+      asOfs <- instantTrials
+        .listsOfSize(bigShuffledHistoryOverLotsOfThings.size)
+        .map(_.sorted)
+      queryWhen <- unboundedInstantTrials
+    } yield HistoryTestCase(
+      recordingsGroupedById,
+      bigShuffledHistoryOverLotsOfThings,
+      asOfs,
+      queryWhen
+    )
+
+    testCaseTrials.withLimit(200).dynamicTests {
+      case HistoryTestCase(
+            recordingsGroupedById,
+            bigShuffledHistoryOverLotsOfThings,
+            asOfs,
+            queryWhen
+          ) =>
+        Using.resource(makeWorld()) { world =>
+          recordEventsInWorld(
+            bigShuffledHistoryOverLotsOfThings,
+            asOfs,
+            world
+          )
+
+          val scope = world.scopeFor(queryWhen, world.nextRevision)
+
+          val checks = for {
+            recording <- recordingsGroupedById
+            RecordingsNoLaterThan(
+              historyId,
+              historiesFrom,
+              pertinentRecordings,
+              _,
+              _
+            ) <- recording.thePartNoLaterThan(
+              queryWhen
+            )
+            Seq(history) = historiesFrom(scope)
+          } yield (
+            historyId,
+            history.datums,
+            pertinentRecordings.map(_._1)
+          )
+
+          if (checks.isEmpty) Trials.reject()
+
+          for ((historyId, actualHistory, expectedHistory) <- checks) {
+            withClue(s"History mismatch for history id: $historyId.") {
+              assert(actualHistory == expectedHistory)
+            }
+          }
+        }
+    }
+  }
+
+
+
+
+
+
 
 
 

--- a/src/test/scala/com/sageserpent/plutonium/WorldBehaviourAmericium.scala
+++ b/src/test/scala/com/sageserpent/plutonium/WorldBehaviourAmericium.scala
@@ -3224,6 +3224,55 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
   }
 
 @TestFactory
+  def forbidTheBookingOfEventsThatOnlyEverReferToAnItemViaAnAbstractType(): DynamicTests = {
+    val testCaseTrials = for {
+      recordingsForAbstractedHistoriesGroupedById <-
+        recordingsGroupedByIdTrials_(
+          abstractedDataSamplesForAnIdTrials,
+          forbidAnnihilations = true
+        )
+      obsoleteRecordingsGroupedById <-
+        nonConflictingRecordingsGroupedByIdTrials
+      shuffledRecordingsForAbstractedHistories <-
+        shuffleRecordingsPreservingRelativeOrderOfEventsAtTheSameWhen(
+          recordingsForAbstractedHistoriesGroupedById
+        )
+      shuffledObsoleteRecordings <-
+        shuffleRecordingsPreservingRelativeOrderOfEventsAtTheSameWhen(
+          obsoleteRecordingsGroupedById
+        )
+      bigShuffledHistoryOverLotsOfThings <- intersperseObsoleteEventsAmericium(
+        shuffledRecordingsForAbstractedHistories,
+        shuffledObsoleteRecordings
+      )
+      asOfs <- instantTrials
+        .listsOfSize(bigShuffledHistoryOverLotsOfThings.length)
+        .map(_.sorted)
+    } yield AbstractConcreteTypeTestCase(
+      bigShuffledHistoryOverLotsOfThings,
+      asOfs
+    )
+
+    testCaseTrials.withLimit(200).dynamicTests {
+      case AbstractConcreteTypeTestCase(
+            bigShuffledHistoryOverLotsOfThings,
+            asOfs
+          ) =>
+        Using.resource(makeWorld()) { world =>
+          assertThrows(
+            classOf[UnsupportedOperationException],
+            () =>
+              recordEventsInWorld(
+                bigShuffledHistoryOverLotsOfThings,
+                asOfs,
+                world
+              )
+          )
+        }
+    }
+  }
+
+@TestFactory
   def extendTheHistoryOfAnItemWhoseAnnihilationIsAnnulledToPickUpAnySubsequentEventsRelatingToThatItem()
       : DynamicTests = {
     val itemId = "Fred"
@@ -3536,6 +3585,8 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
         }
     }
   }
+
+
 
 
 

--- a/src/test/scala/com/sageserpent/plutonium/WorldBehaviourAmericium.scala
+++ b/src/test/scala/com/sageserpent/plutonium/WorldBehaviourAmericium.scala
@@ -324,6 +324,36 @@ object WorldBehaviourAmericium {
       revisionOffsetToCheckAt: Int
   )
 
+  case class ArbitraryScopesTestCase(
+      testCaseSubsections: Seq[
+        (List[WorldSpecSupportAmericium#RecordingsForAnId], Seq[Seq[(Option[(Unbounded[Instant], Event)], intersperseObsoleteEventsAmericium.EventId)]])
+      ],
+      asOfsForSubsections: Seq[Seq[Instant]],
+      queryWhen: Unbounded[Instant]
+  )
+
+  case class AnnulAndRewriteAtSameAsOfTestCase(
+      recordingsGroupedById: Seq[WorldSpecSupportAmericium#RecordingsForAnId],
+      bigShuffledHistoryOverLotsOfThings: Seq[
+        Seq[
+          (
+              Option[(Unbounded[Instant], Event)],
+              intersperseObsoleteEventsAmericium.EventId
+          )
+        ]
+      ],
+      annulmentsGalore: Seq[
+        Seq[
+          (
+              Option[(Unbounded[Instant], Event)],
+              intersperseObsoleteEventsAmericium.EventId
+          )
+        ]
+      ],
+      asOfs: Seq[Instant],
+      queryWhen: Unbounded[Instant]
+  )
+
   case class AnnulledAnnihilationTestCase(
       bigShuffledHistoryOverLotsOfThings: Seq[
         Seq[
@@ -373,7 +403,7 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
   import cats.implicits._
 
 @TestFactory
-  def worldWithNoHistory(): DynamicTests = {
+  def notContainAnyIdentifiables(): DynamicTests = {
     val scopeTrials = for {
       when <- unboundedInstantTrials
       asOf <- instantTrials
@@ -4139,6 +4169,301 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
         }
     }
   }
+
+@TestFactory
+  def yieldAHistoryWhoseVersionsOfEventsReflectArbitraryScopesMadeFromItAtVaryingRevisions(): DynamicTests = {
+    val testCaseSubSectionTrials = for {
+      recordingsGroupedById <- recordingsGroupedByIdTrials(
+        forbidAnnihilations = false
+      )
+      obsoleteRecordingsGroupedById <-
+        nonConflictingRecordingsGroupedByIdTrials
+      shuffledRecordings <-
+        shuffleRecordingsPreservingRelativeOrderOfEventsAtTheSameWhen(
+          recordingsGroupedById
+        )
+      shuffledObsoleteRecordings <-
+        shuffleRecordingsPreservingRelativeOrderOfEventsAtTheSameWhen(
+          obsoleteRecordingsGroupedById
+        )
+      bigShuffledHistoryOverLotsOfThings <- intersperseObsoleteEventsAmericium(
+        shuffledRecordings,
+        shuffledObsoleteRecordings
+      )
+    } yield (recordingsGroupedById, bigShuffledHistoryOverLotsOfThings)
+
+    val testCaseTrials = for {
+      testCaseSubsections <- testCaseSubSectionTrials.listsOfSize(4)
+      subsectionLengths = testCaseSubsections.map(_._2.length)
+      asOfsForSubsections <- {
+        val numberOfEventsOverall = subsectionLengths.sum
+        instantTrials.listsOfSize(numberOfEventsOverall).map(_.sorted).map(allAsOfs => {
+          def chunksOf(
+                        chunkSizes: Seq[Int],
+                        articles: List[Instant]
+                      ): List[List[Instant]] =
+            chunkSizes match {
+              case chunkSize :: remainingChunkSizes =>
+                val (chunkOfStuff, remainingArticles) = articles splitAt chunkSize
+                chunkOfStuff :: chunksOf(remainingChunkSizes, remainingArticles)
+              case Nil => Nil
+            }
+
+          chunksOf(subsectionLengths, allAsOfs)
+        })
+      }
+      queryWhen <- unboundedInstantTrials
+    } yield ArbitraryScopesTestCase(
+      testCaseSubsections,
+      asOfsForSubsections,
+      queryWhen
+    )
+
+    testCaseTrials.withLimit(200).dynamicTests {
+      case ArbitraryScopesTestCase(
+            testCaseSubsections,
+            asOfsForSubsections,
+            queryWhen
+          ) =>
+        Using.resource(makeWorld()) { world =>
+          def listOfRevisionsToCheckAtAndRecordingsGroupedById(
+              subsections: Seq[
+                (
+                    (
+                        List[WorldSpecSupportAmericium#RecordingsForAnId],
+                        Seq[
+                          Seq[
+                            (
+                                Option[(Unbounded[Instant], Event)],
+                                intersperseObsoleteEventsAmericium.EventId
+                            )
+                          ]
+                        ]
+                    ),
+                    Seq[Instant]
+                )
+              ],
+              maximumEventIdFromPreviousSubsection: intersperseObsoleteEventsAmericium.EventId
+          ): LazyList[(World.Revision, List[WorldSpecSupportAmericium#RecordingsForAnId])] =
+            subsections match {
+              case (
+                    (
+                      recordingsGroupedById,
+                      bigShuffledHistoryOverLotsOfThings
+                    ),
+                    asOfs
+                  ) :: remainingSubsections =>
+                val sortedEventIds =
+                  (bigShuffledHistoryOverLotsOfThings.flatMap(_.map(_._2))).sorted.distinct
+                assert(0 == sortedEventIds.head)
+                assert((sortedEventIds zip sortedEventIds.tail).forall {
+                  case (first, second) => 1 + first == second
+                })
+                val maximumEventIdFromThisSubsection =
+                  sortedEventIds.last
+                val annulmentsForExtraEventIdsNotCorrectedInThisSubsection =
+                  Seq(
+                    (1 + maximumEventIdFromThisSubsection) to maximumEventIdFromPreviousSubsection map ((None: Option[
+                      (Unbounded[Instant], Event)
+                    ]) -> _)
+                  )
+                val asOfForAnnulments = asOfs.head
+                try {
+                  if (world.revisionAsOfs.nonEmpty && asOfForAnnulments.isBefore(world.revisionAsOfs.last)) {
+                    throw new RuntimeException("Inconsistent asOf for annulments")
+                  }
+                  recordEventsInWorld(
+                    annulmentsForExtraEventIdsNotCorrectedInThisSubsection,
+                    List(asOfForAnnulments),
+                    world
+                  )
+                  if (asOfs.nonEmpty && asOfs.head.isBefore(world.revisionAsOfs.last)) {
+                    throw new RuntimeException("Inconsistent asOf for history")
+                  }
+                  recordEventsInWorld(
+                    bigShuffledHistoryOverLotsOfThings,
+                    asOfs.toList,
+                    world
+                  )
+                } catch {
+                  case _: RuntimeException =>
+                    assert(World.initialRevision != world.nextRevision)
+                    val asOfForAllCorrections = asOfs.last
+
+                    val annulmentsGalore = List(
+                      (0 to (maximumEventIdFromPreviousSubsection max maximumEventIdFromThisSubsection)) map ((None: Option[
+                        (Unbounded[Instant], Event)
+                      ]) -> _)
+                    )
+
+                    recordEventsInWorld(
+                      annulmentsGalore,
+                      List(asOfForAllCorrections),
+                      world
+                    )
+                    recordEventsInWorld(
+                      bigShuffledHistoryOverLotsOfThings,
+                      List.fill(asOfs.length)(asOfForAllCorrections),
+                      world
+                    )
+                }
+
+                (world.nextRevision -> recordingsGroupedById) #:: listOfRevisionsToCheckAtAndRecordingsGroupedById(
+                  remainingSubsections,
+                  maximumEventIdFromThisSubsection
+                )
+              case _ => LazyList.empty
+            }
+
+          val checks = (for {
+            (revision, recordingsGroupedById) <-
+              listOfRevisionsToCheckAtAndRecordingsGroupedById(
+                testCaseSubsections zip asOfsForSubsections,
+                -1
+              )
+          } yield {
+            val scope = world.scopeFor(queryWhen, revision)
+
+            val checks = for {
+              recording <- recordingsGroupedById
+              RecordingsNoLaterThan(
+                historyId,
+                historiesFrom,
+                pertinentRecordings,
+                _,
+                _
+              ) <- recording.thePartNoLaterThan(
+                queryWhen
+              )
+              Seq(history) = historiesFrom(scope)
+            } yield (
+              historyId,
+              history.datums,
+              pertinentRecordings.map(_._1)
+            )
+
+            for ((historyId, actualHistory, expectedHistory) <- checks) {
+              withClue(s"History mismatch for history id: $historyId.") {
+                assert(actualHistory == expectedHistory)
+              }
+            }
+          }).toList
+
+          if (checks.isEmpty) Trials.reject()
+        }
+    }
+  }
+
+@TestFactory
+  def allowAnEntireHistoryToBeCompletelyAnnulledAndThenRewrittenAtTheSameAsOf(): DynamicTests = {
+    val testCaseTrials = for {
+      recordingsGroupedById <- recordingsGroupedByIdTrials(
+        forbidAnnihilations = false
+      )
+      shuffledRecordings <-
+        shuffleRecordingsPreservingRelativeOrderOfEventsAtTheSameWhen(
+          recordingsGroupedById
+        )
+      bigShuffledHistoryOverLotsOfThings <- api
+        .splitsIntoNonEmptyPieces(shuffledRecordings.zipWithIndex)
+        .map(liftRecordings)
+      allEventIds = bigShuffledHistoryOverLotsOfThings.flatten.map(_._2)
+      annulmentsGalore = List(
+        allEventIds.map((None: Option[(Unbounded[Instant], Event)]) -> _)
+      )
+      historyLength = bigShuffledHistoryOverLotsOfThings.length
+      asOfs <- instantTrials
+        .listsOfSize(historyLength)
+        .map(_.sorted)
+      queryWhen <- unboundedInstantTrials
+    } yield AnnulAndRewriteAtSameAsOfTestCase(
+      recordingsGroupedById,
+      bigShuffledHistoryOverLotsOfThings,
+      annulmentsGalore,
+      asOfs,
+      queryWhen
+    )
+
+    testCaseTrials.withLimit(200).dynamicTests {
+      case AnnulAndRewriteAtSameAsOfTestCase(
+            recordingsGroupedById,
+            bigShuffledHistoryOverLotsOfThings,
+            annulmentsGalore,
+            asOfs,
+            queryWhen
+          ) =>
+        Using.resource(makeWorld()) { world =>
+          // Define a history the first time around...
+
+          recordEventsInWorld(
+            bigShuffledHistoryOverLotsOfThings,
+            asOfs,
+            world
+          )
+
+          val scopeForFirstHistory =
+            world.scopeFor(queryWhen, world.nextRevision)
+
+          val firstHistory =
+            historyFrom(world, recordingsGroupedById)(
+              scopeForFirstHistory
+            )
+
+          // Annul that history completely...
+
+          val asOfForCorrections = asOfs.last
+
+          recordEventsInWorld(
+            annulmentsGalore,
+            List(asOfForCorrections),
+            world
+          )
+
+          val scopeAfterAnnulments =
+            world.scopeFor(queryWhen, world.nextRevision)
+
+          val historyAfterAnnulments =
+            historyFrom(world, recordingsGroupedById)(
+              scopeAfterAnnulments
+            )
+
+          // ...and then recreate what should be the same history.
+
+          recordEventsInWorld(
+            bigShuffledHistoryOverLotsOfThings,
+            List.fill(bigShuffledHistoryOverLotsOfThings.length)(
+              asOfForCorrections
+            ),
+            world
+          )
+
+          val scopeForSecondHistory =
+            world.scopeFor(queryWhen, world.nextRevision)
+
+          val secondHistory =
+            historyFrom(world, recordingsGroupedById)(
+              scopeForSecondHistory
+            )
+
+          withClue(s"History after annulments should be empty.") {
+            assert(historyAfterAnnulments.isEmpty)
+          }
+          withClue(s"History after rewrite should match first history.") {
+            assert(firstHistory == secondHistory)
+          }
+        }
+    }
+  }
+
+
+
+
+
+
+
+
+
+
 
 
 

--- a/src/test/scala/com/sageserpent/plutonium/WorldBehaviourAmericium.scala
+++ b/src/test/scala/com/sageserpent/plutonium/WorldBehaviourAmericium.scala
@@ -285,6 +285,30 @@ object WorldBehaviourAmericium {
       queryWhen: Instant
   )
 
+  case class AnnulAndRewriteTestCase(
+      recordingsGroupedById: Seq[WorldSpecSupportAmericium#RecordingsForAnId],
+      bigShuffledHistoryOverLotsOfThings: Seq[
+        Seq[
+          (
+              Option[(Unbounded[Instant], Event)],
+              intersperseObsoleteEventsAmericium.EventId
+          )
+        ]
+      ],
+      annulmentsGalore: Seq[
+        Seq[
+          (
+              Option[(Unbounded[Instant], Event)],
+              intersperseObsoleteEventsAmericium.EventId
+          )
+        ]
+      ],
+      asOfsForFirstHistory: Seq[Instant],
+      asOfsForAnnulments: Seq[Instant],
+      asOfsForSecondHistory: Seq[Instant],
+      queryWhen: Unbounded[Instant]
+  )
+
   case class AnnulledAnnihilationTestCase(
       bigShuffledHistoryOverLotsOfThings: Seq[
         Seq[
@@ -3889,6 +3913,128 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
         }
     }
   }
+
+@TestFactory
+  def allowAnEntireHistoryToBeCompletelyAnnulledAndThenRewritten(): DynamicTests = {
+    val testCaseTrials = for {
+      recordingsGroupedById <- recordingsGroupedByIdTrials(
+        forbidAnnihilations = true
+      )
+      shuffledRecordings <- shuffleRecordingsPreservingRelativeOrderOfEventsAtTheSameWhen(
+        recordingsGroupedById
+      )
+      bigShuffledHistoryOverLotsOfThings <- intersperseObsoleteEventsAmericium
+        .chunkKeepingEventIdsUniquePerChunk(
+          shuffledRecordings.zipWithIndex.map { case (stuff, eventId) =>
+            Some(stuff) -> eventId
+          }
+        )
+      allEventIds = bigShuffledHistoryOverLotsOfThings.flatten.map(_._2)
+      maximumEventId = allEventIds.max
+      eventIdsThatMayBeSpuriousAndDuplicated <- api
+        .chooseSeveralOf(
+          allEventIds,
+          1
+        ) // Dummy to get started, need a way to choose any number
+        .flatMap(_ =>
+          api.integers(0, allEventIds.length).flatMap(api.chooseSeveralOf(allEventIds, _))
+        )
+        .map(chosen =>
+          allEventIds ++ chosen ++ (1 + maximumEventId to 10 + maximumEventId)
+        )
+
+      annulmentsGalore <- api
+        .shuffles(eventIdsThatMayBeSpuriousAndDuplicated)
+        .flatMap(shuffledIds =>
+          intersperseObsoleteEventsAmericium.chunkKeepingEventIdsUniquePerChunk(
+            shuffledIds.map((None: Option[(Unbounded[Instant], Event)]) -> _)
+          )
+        )
+      historyLength    = bigShuffledHistoryOverLotsOfThings.length
+      annulmentsLength = annulmentsGalore.length
+      asOfs <- instantTrials
+        .listsOfSize(2 * historyLength + annulmentsLength)
+        .map(_.sorted)
+      (asOfsForFirstHistory, remainingAsOfs) = asOfs splitAt historyLength
+      (asOfsForAnnulments, asOfsForSecondHistory) =
+        remainingAsOfs splitAt annulmentsLength
+      queryWhen <- unboundedInstantTrials
+    } yield AnnulAndRewriteTestCase(
+      recordingsGroupedById,
+      bigShuffledHistoryOverLotsOfThings,
+      annulmentsGalore,
+      asOfsForFirstHistory,
+      asOfsForAnnulments,
+      asOfsForSecondHistory,
+      queryWhen
+    )
+
+    testCaseTrials.withLimit(200).dynamicTests {
+      case testCase @ AnnulAndRewriteTestCase(
+            recordingsGroupedById,
+            bigShuffledHistoryOverLotsOfThings,
+            annulmentsGalore,
+            asOfsForFirstHistory,
+            asOfsForAnnulments,
+            asOfsForSecondHistory,
+            queryWhen
+          ) =>
+        Using.resource(makeWorld()) { world =>
+          // Define a history the first time around...
+
+          recordEventsInWorld(
+            bigShuffledHistoryOverLotsOfThings,
+            asOfsForFirstHistory,
+            world
+          )
+
+          val scopeForFirstHistory =
+            world.scopeFor(queryWhen, world.nextRevision)
+
+          val firstHistory =
+            historyFrom(world, recordingsGroupedById)(
+              scopeForFirstHistory
+            )
+
+          // Annul that history completely...
+
+          recordEventsInWorld(annulmentsGalore, asOfsForAnnulments, world)
+
+          val scopeAfterAnnulments =
+            world.scopeFor(queryWhen, world.nextRevision)
+
+          val historyAfterAnnulments =
+            historyFrom(world, recordingsGroupedById)(
+              scopeAfterAnnulments
+            )
+
+          // ...and then recreate what should be the same history.
+
+          recordEventsInWorld(
+            bigShuffledHistoryOverLotsOfThings,
+            asOfsForSecondHistory,
+            world
+          )
+
+          val scopeForSecondHistory =
+            world.scopeFor(queryWhen, world.nextRevision)
+
+          val secondHistory =
+            historyFrom(world, recordingsGroupedById)(
+              scopeForSecondHistory
+            )
+
+          withClue(s"History after annulments should be empty: $historyAfterAnnulments") {
+            assert(historyAfterAnnulments.isEmpty)
+          }
+          withClue(s"History after rewrite should match first history.") {
+            assert(firstHistory == secondHistory)
+          }
+        }
+    }
+  }
+
+
 
 
 

--- a/src/test/scala/com/sageserpent/plutonium/WorldBehaviourAmericium.scala
+++ b/src/test/scala/com/sageserpent/plutonium/WorldBehaviourAmericium.scala
@@ -3932,13 +3932,8 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
       allEventIds = bigShuffledHistoryOverLotsOfThings.flatten.map(_._2)
       maximumEventId = allEventIds.max
       eventIdsThatMayBeSpuriousAndDuplicated <- api
-        .chooseSeveralOf(
-          allEventIds,
-          1
-        ) // Dummy to get started, need a way to choose any number
-        .flatMap(_ =>
-          api.integers(0, allEventIds.length).flatMap(api.chooseSeveralOf(allEventIds, _))
-        )
+        .integers(0, allEventIds.length)
+        .flatMap(api.chooseSeveralOf(allEventIds, _))
         .map(chosen =>
           allEventIds ++ chosen ++ (1 + maximumEventId to 10 + maximumEventId)
         )

--- a/src/test/scala/com/sageserpent/plutonium/WorldBehaviourAmericium.scala
+++ b/src/test/scala/com/sageserpent/plutonium/WorldBehaviourAmericium.scala
@@ -216,6 +216,20 @@ object WorldBehaviourAmericium {
       queryWhen: Unbounded[Instant]
   )
 
+  case class InconsistentTypeTestCase(
+      recordingsGroupedById: Seq[WorldSpecSupportAmericium#RecordingsForAnId],
+      bigShuffledHistoryOverLotsOfThings: Seq[
+        Seq[
+          (
+              Option[(Unbounded[Instant], Event)],
+              intersperseObsoleteEventsAmericium.EventId
+          )
+        ]
+      ],
+      asOfs: Seq[Instant],
+      whenAnInconsistentEventOccurs: Unbounded[Instant]
+  )
+
   case class PreciseTypeAnnihilationTestCase(
       recordingsGroupedById: Seq[WorldSpecSupportAmericium#RecordingsForAnId],
       bigShuffledHistoryOverLotsOfThings: Seq[
@@ -2791,6 +2805,143 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
   }
 
 @TestFactory
+  def forbidRecordingOfEventsThatHaveInconsistentViewsOfTheTypeOfAnItemReferencedByAnId(): DynamicTests = {
+    val testCaseTrials = for {
+      recordingsGroupedById <- variablyTypedRecordingsGroupedByIdTrials
+      obsoleteRecordingsGroupedById <-
+        nonConflictingRecordingsGroupedByIdTrials
+      shuffledRecordings <-
+        shuffleRecordingsPreservingRelativeOrderOfEventsAtTheSameWhen(
+          recordingsGroupedById
+        )
+      shuffledObsoleteRecordings <-
+        shuffleRecordingsPreservingRelativeOrderOfEventsAtTheSameWhen(
+          obsoleteRecordingsGroupedById
+        )
+      bigShuffledHistoryOverLotsOfThings <- intersperseObsoleteEventsAmericium(
+        shuffledRecordings,
+        shuffledObsoleteRecordings
+      )
+      asOfs <- instantTrials
+        .listsOfSize(bigShuffledHistoryOverLotsOfThings.size)
+        .map(_.sorted)
+      whenAnInconsistentEventOccurs <- unboundedInstantTrials
+    } yield InconsistentTypeTestCase(
+      recordingsGroupedById,
+      bigShuffledHistoryOverLotsOfThings,
+      asOfs,
+      whenAnInconsistentEventOccurs
+    )
+
+    testCaseTrials.withLimit(200).dynamicTests {
+      case InconsistentTypeTestCase(
+            recordingsGroupedById,
+            bigShuffledHistoryOverLotsOfThings,
+            asOfs,
+            whenAnInconsistentEventOccurs
+          ) =>
+        Using.resource(makeWorld()) { world =>
+          val numberOfEvents = bigShuffledHistoryOverLotsOfThings.size
+
+          val sizeOfPartOne = 1 min (numberOfEvents / 2)
+
+          val (historyPartOne, historyPartTwo) =
+            bigShuffledHistoryOverLotsOfThings splitAt sizeOfPartOne
+
+          val (asOfsPartOne, asOfsPartTwo) = asOfs splitAt sizeOfPartOne
+
+          recordEventsInWorld(historyPartOne, asOfsPartOne, world)
+
+          val queryScope = world
+            .scopeFor(whenAnInconsistentEventOccurs, world.nextRevision)
+
+          val eventIdForExtraConsistentChange  = -1
+          val eventIdForInconsistentChangeOnly = -2
+
+          val checks = for {
+            recording <- recordingsGroupedById
+            fooHistoryId <- recording.historyId match {
+              case id: MoreSpecificFooHistory#Id => Some(id)
+              case _                             => None
+            }
+            if queryScope
+              .render(
+                Bitemporal.withId[MoreSpecificFooHistory](fooHistoryId)
+              ) exists (_.isInstanceOf[MoreSpecificFooHistory])
+          } yield fooHistoryId
+
+          for (fooHistoryId <- checks) {
+            assertThrows(
+              classOf[RuntimeException],
+              () => {
+                val consistentButLooselyTypedChange =
+                  Change.forOneItem[FooHistory](
+                    fooHistoryId,
+                    { fooHistory: FooHistory =>
+                      fooHistory.property1 = "Hello"
+                    }
+                  )
+                val inconsistentlyTypedChange =
+                  Change.forOneItem[AnotherSpecificFooHistory](
+                    whenAnInconsistentEventOccurs
+                  )(
+                    fooHistoryId
+                      .asInstanceOf[AnotherSpecificFooHistory#Id],
+                    {
+                      anotherSpecificFooHistory: AnotherSpecificFooHistory =>
+                        anotherSpecificFooHistory.property3 =
+                          6 // Have to actually *update* to cause an inconsistency.
+                    }
+                  )
+                world.revise(
+                  Map(
+                    eventIdForExtraConsistentChange -> Some(
+                      consistentButLooselyTypedChange
+                    ),
+                    eventIdForInconsistentChangeOnly -> Some(
+                      inconsistentlyTypedChange
+                    )
+                  ),
+                  world.revisionAsOfs.lastOption.getOrElse(asOfs.head)
+                )
+              }
+            )
+          }
+
+          recordEventsInWorld(historyPartTwo, asOfsPartTwo, world)
+
+          val scope = world.scopeFor(PositiveInfinity, world.nextRevision)
+
+          val finalChecks = for {
+            recording <- recordingsGroupedById
+            RecordingsNoLaterThan(
+              historyId,
+              historiesFrom,
+              pertinentRecordings,
+              _,
+              _
+            ) <- recording.thePartNoLaterThan(
+              PositiveInfinity
+            )
+            Seq(history) = historiesFrom(scope)
+          } yield (
+            historyId,
+            history.datums,
+            pertinentRecordings.map(_._1)
+          )
+
+          if (finalChecks.isEmpty) Trials.reject()
+
+          for ((historyId, actualHistory, expectedHistory) <- finalChecks) {
+            withClue(s"History mismatch for history id: $historyId.") {
+              assert(actualHistory == expectedHistory)
+            }
+          }
+        }
+    }
+  }
+
+@TestFactory
   def extendTheHistoryOfAnItemWhoseAnnihilationIsAnnulledToPickUpAnySubsequentEventsRelatingToThatItem()
       : DynamicTests = {
     val itemId = "Fred"
@@ -3103,6 +3254,8 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
         }
     }
   }
+
+
 
 
 

--- a/src/test/scala/com/sageserpent/plutonium/WorldBehaviourAmericium.scala
+++ b/src/test/scala/com/sageserpent/plutonium/WorldBehaviourAmericium.scala
@@ -3551,11 +3551,12 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
         )
       bigShuffledHistoryOverLotsOfThings <- api
         .splitsIntoNonEmptyPieces(shuffledRecordings.zipWithIndex)
+        .map(liftRecordings)
       asOfs <- instantTrials
         .listsOfSize(bigShuffledHistoryOverLotsOfThings.size)
         .map(_.sorted)
     } yield AnnulledAnnihilationTestCase(
-      liftRecordings(bigShuffledHistoryOverLotsOfThings),
+      bigShuffledHistoryOverLotsOfThings,
       asOfs,
       steps,
       annihilationWhen
@@ -3925,10 +3926,9 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
       )
       bigShuffledHistoryOverLotsOfThings <- intersperseObsoleteEventsAmericium
         .chunkKeepingEventIdsUniquePerChunk(
-          shuffledRecordings.zipWithIndex.map { case (stuff, eventId) =>
-            Some(stuff) -> eventId
-          }
+          shuffledRecordings.zipWithIndex
         )
+        .map(liftRecordings)
       allEventIds = bigShuffledHistoryOverLotsOfThings.flatten.map(_._2)
       maximumEventId = allEventIds.max
       eventIdsThatMayBeSpuriousAndDuplicated <- api

--- a/src/test/scala/com/sageserpent/plutonium/WorldBehaviourAmericium.scala
+++ b/src/test/scala/com/sageserpent/plutonium/WorldBehaviourAmericium.scala
@@ -156,6 +156,20 @@ object WorldBehaviourAmericium {
       asOfs: Seq[Instant]
   )
 
+  case class MixedAbstractConcreteTestCase(
+      recordingsGroupedById: Seq[WorldSpecSupportAmericium#RecordingsForAnId],
+      bigShuffledHistoryOverLotsOfThings: Seq[
+        Seq[
+          (
+              Option[(Unbounded[Instant], Event)],
+              intersperseObsoleteEventsAmericium.EventId
+          )
+        ]
+      ],
+      asOfs: Seq[Instant],
+      queryWhen: Unbounded[Instant]
+  )
+
   case class ScopeAsOfTestCase(
       bigShuffledHistoryOverLotsOfThings: Seq[
         Seq[
@@ -3120,6 +3134,96 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
   }
 
 @TestFactory
+  def recordBookingsFromEventsUsingAbstractTypesInTheSameMannerAsForConcreteTypes(): DynamicTests = {
+    val testCaseTrials: Trials[MixedAbstractConcreteTestCase] = for {
+      recordingsGroupedById <- mixedAbstractedAndImplementingRecordingsGroupedByIdTrials(
+        forbidAnnihilations = true
+      )
+      obsoleteRecordingsGroupedById <-
+        nonConflictingRecordingsGroupedByIdTrials
+      shuffledRecordings <-
+        shuffleRecordingsPreservingRelativeOrderOfEventsAtTheSameWhen(
+          recordingsGroupedById
+        )
+      shuffledObsoleteRecordings <-
+        shuffleRecordingsPreservingRelativeOrderOfEventsAtTheSameWhen(
+          obsoleteRecordingsGroupedById
+        )
+      bigShuffledHistoryOverLotsOfThings <- intersperseObsoleteEventsAmericium(
+        shuffledRecordings,
+        shuffledObsoleteRecordings
+      )
+      asOfs <- instantTrials
+        .listsOfSize(bigShuffledHistoryOverLotsOfThings.size)
+        .map(_.sorted)
+      queryWhen <- unboundedInstantTrials
+    } yield MixedAbstractConcreteTestCase(
+      recordingsGroupedById,
+      bigShuffledHistoryOverLotsOfThings,
+      asOfs,
+      queryWhen
+    )
+
+    testCaseTrials.withLimit(200).dynamicTests {
+      case MixedAbstractConcreteTestCase(
+            recordingsGroupedById,
+            bigShuffledHistoryOverLotsOfThings,
+            asOfs,
+            queryWhen
+          ) =>
+        Using.resource(makeWorld()) { world =>
+          try {
+            recordEventsInWorld(
+              bigShuffledHistoryOverLotsOfThings,
+              asOfs,
+              world
+            )
+
+            val scope =
+              world.scopeFor(queryWhen, world.nextRevision)
+
+            val checks =
+              for {
+                recording <- recordingsGroupedById
+                RecordingsNoLaterThan(
+                  historyId,
+                  historiesFrom,
+                  pertinentRecordings,
+                  _,
+                  _
+                ) <-
+                  recording.thePartNoLaterThan(
+                    queryWhen
+                  )
+                Seq(history) = historiesFrom(scope)
+                haveBothAnAbstractedAndAnImplementingDatumSomewhere =
+                  history.datums
+                    .exists { case datum: Int =>
+                      datum > 0
+                    } && history.datums
+                    .exists { case datum: Int => datum < 0 }
+                if haveBothAnAbstractedAndAnImplementingDatumSomewhere
+              } yield (
+                historyId,
+                history.datums,
+                pertinentRecordings.map(_._1)
+              )
+
+            if (checks.isEmpty) Trials.reject()
+
+            for ((historyId, actualHistory, expectedHistory) <- checks) {
+              withClue(s"History mismatch for history id: $historyId.") {
+                assert(actualHistory == expectedHistory)
+              }
+            }
+          } catch {
+            case _: UnsupportedOperationException => Trials.reject()
+          }
+        }
+    }
+  }
+
+@TestFactory
   def extendTheHistoryOfAnItemWhoseAnnihilationIsAnnulledToPickUpAnySubsequentEventsRelatingToThatItem()
       : DynamicTests = {
     val itemId = "Fred"
@@ -3432,6 +3536,8 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
         }
     }
   }
+
+
 
 
 

--- a/src/test/scala/com/sageserpent/plutonium/WorldBehaviourAmericium.scala
+++ b/src/test/scala/com/sageserpent/plutonium/WorldBehaviourAmericium.scala
@@ -230,6 +230,18 @@ object WorldBehaviourAmericium {
       whenAnInconsistentEventOccurs: Unbounded[Instant]
   )
 
+  case class AbstractConcreteTypeTestCase(
+      bigShuffledHistoryOverLotsOfThings: Seq[
+        Seq[
+          (
+              Option[(Unbounded[Instant], Event)],
+              intersperseObsoleteEventsAmericium.EventId
+          )
+        ]
+      ],
+      asOfs: Seq[Instant]
+  )
+
   case class PreciseTypeAnnihilationTestCase(
       recordingsGroupedById: Seq[WorldSpecSupportAmericium#RecordingsForAnId],
       bigShuffledHistoryOverLotsOfThings: Seq[
@@ -2942,6 +2954,172 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
   }
 
 @TestFactory
+  def allowEventsToReferToAnItemViaAnAbstractTypeProvidedItIsDefinedConcretelyInOtherEvents()
+      : DynamicTests = {
+    val testCaseTrials = for {
+      sharedIds <- abstractedOrImplementingHistoryIdTrials.nonEmptySets
+      recordingsForAbstractedHistoriesGroupedById <-
+        recordingsGroupedByIdTrials_(
+          dataSamplesForAnIdTrials[AbstractedHistory](
+            api.choose(sharedIds),
+            abstractedHistoryPositiveIntegerDataSampleTrials(faulty = false)
+          ),
+          forbidAnnihilations = true
+        )
+      recordingsForImplementingHistoriesGroupedById <-
+        recordingsGroupedByIdTrials_(
+          dataSamplesForAnIdTrials[ImplementingHistory](
+            api.choose(sharedIds),
+            implementingHistoryNegativeIntegerDataSampleTrials(faulty = false)
+          ),
+          forbidAnnihilations = true
+        )
+      // Only keep the recordings for IDs that actually ended up being shared.
+      idsForAbstractedHistories =
+        recordingsForAbstractedHistoriesGroupedById
+          .map(_.historyId)
+          .toSet
+      idsForImplementingHistories =
+        recordingsForImplementingHistoriesGroupedById
+          .map(_.historyId)
+          .toSet
+      actuallySharedIds =
+        idsForAbstractedHistories intersect idsForImplementingHistories
+      if actuallySharedIds.nonEmpty
+
+      relevantRecordingsForAbstractedHistoriesGroupedById =
+        recordingsForAbstractedHistoriesGroupedById filter (recordings =>
+          actuallySharedIds.contains(recordings.historyId)
+        )
+      relevantRecordingsForImplementedHistoriesGroupedById =
+        recordingsForImplementingHistoriesGroupedById filter (recordings =>
+          actuallySharedIds.contains(recordings.historyId)
+        )
+
+      shuffledRecordingsForAbstractedHistories <-
+        shuffleRecordingsPreservingRelativeOrderOfEventsAtTheSameWhen(
+          relevantRecordingsForAbstractedHistoriesGroupedById
+        )
+      shuffledRecordingsForImplementingHistories <-
+        shuffleRecordingsPreservingRelativeOrderOfEventsAtTheSameWhen(
+          relevantRecordingsForImplementedHistoriesGroupedById
+        )
+      bigShuffledHistoryOverLotsOfThingsThatMakesSureThatAtLeastOneImplementingHistoryGetsBookedInFirst <-
+        api
+          .splitsIntoNonEmptyPieces(
+            (shuffledRecordingsForImplementingHistories ++ shuffledRecordingsForAbstractedHistories).zipWithIndex
+          )
+          .map(liftRecordings)
+
+      asOfs <- instantTrials
+        .listsOfSize(
+          bigShuffledHistoryOverLotsOfThingsThatMakesSureThatAtLeastOneImplementingHistoryGetsBookedInFirst.length
+        )
+        .map(_.sorted)
+    } yield AbstractConcreteTypeTestCase(
+      bigShuffledHistoryOverLotsOfThingsThatMakesSureThatAtLeastOneImplementingHistoryGetsBookedInFirst,
+      asOfs
+    )
+
+    testCaseTrials.withLimit(200).dynamicTests {
+      case AbstractConcreteTypeTestCase(
+            bigShuffledHistoryOverLotsOfThings,
+            asOfs
+          ) =>
+        Using.resource(makeWorld()) { world =>
+          recordEventsInWorld(
+            bigShuffledHistoryOverLotsOfThings,
+            asOfs,
+            world
+          )
+        }
+    }
+  }
+
+@TestFactory
+  def allowEventsToReferToAnItemViaAConcreteTypeWhenItIsDefinedAbstractlyInOtherEvents()
+      : DynamicTests = {
+    val testCaseTrials = for {
+      sharedIds <- abstractedOrImplementingHistoryIdTrials.nonEmptySets
+      recordingsForAbstractedHistoriesGroupedById <-
+        recordingsGroupedByIdTrials_(
+          dataSamplesForAnIdTrials[AbstractedHistory](
+            api.choose(sharedIds),
+            abstractedHistoryPositiveIntegerDataSampleTrials(faulty = false)
+          ),
+          forbidAnnihilations = true
+        )
+      recordingsForImplementingHistoriesGroupedById <-
+        recordingsGroupedByIdTrials_(
+          dataSamplesForAnIdTrials[ImplementingHistory](
+            api.choose(sharedIds),
+            implementingHistoryNegativeIntegerDataSampleTrials(faulty = false)
+          ),
+          forbidAnnihilations = true
+        )
+      // Only keep the recordings for IDs that actually ended up being shared.
+      idsForAbstractedHistories =
+        recordingsForAbstractedHistoriesGroupedById
+          .map(_.historyId)
+          .toSet
+      idsForImplementingHistories =
+        recordingsForImplementingHistoriesGroupedById
+          .map(_.historyId)
+          .toSet
+      actuallySharedIds =
+        idsForAbstractedHistories intersect idsForImplementingHistories
+      if actuallySharedIds.nonEmpty
+
+      relevantRecordingsForAbstractedHistoriesGroupedById =
+        recordingsForAbstractedHistoriesGroupedById filter (recordings =>
+          actuallySharedIds.contains(recordings.historyId)
+        )
+      relevantRecordingsForImplementedHistoriesGroupedById =
+        recordingsForImplementingHistoriesGroupedById filter (recordings =>
+          actuallySharedIds.contains(recordings.historyId)
+        )
+
+      shuffledRecordingsForAbstractedHistories <-
+        shuffleRecordingsPreservingRelativeOrderOfEventsAtTheSameWhen(
+          relevantRecordingsForAbstractedHistoriesGroupedById
+        )
+      shuffledRecordingsForImplementingHistories <-
+        shuffleRecordingsPreservingRelativeOrderOfEventsAtTheSameWhen(
+          relevantRecordingsForImplementedHistoriesGroupedById
+        )
+      bigShuffledHistoryOverLotsOfThingsThatMakesSureThatAtLeastOneImplementingHistoryGetsBookedInFirst <-
+        api
+          .splitsIntoNonEmptyPieces(
+            (shuffledRecordingsForImplementingHistories ++ shuffledRecordingsForAbstractedHistories).zipWithIndex
+          )
+          .map(liftRecordings)
+
+      asOfs <- instantTrials
+        .listsOfSize(
+          bigShuffledHistoryOverLotsOfThingsThatMakesSureThatAtLeastOneImplementingHistoryGetsBookedInFirst.length
+        )
+        .map(_.sorted)
+    } yield AbstractConcreteTypeTestCase(
+      bigShuffledHistoryOverLotsOfThingsThatMakesSureThatAtLeastOneImplementingHistoryGetsBookedInFirst,
+      asOfs
+    )
+
+    testCaseTrials.withLimit(200).dynamicTests {
+      case AbstractConcreteTypeTestCase(
+            bigShuffledHistoryOverLotsOfThings,
+            asOfs
+          ) =>
+        Using.resource(makeWorld()) { world =>
+          recordEventsInWorld(
+            bigShuffledHistoryOverLotsOfThings,
+            asOfs,
+            world
+          )
+        }
+    }
+  }
+
+@TestFactory
   def extendTheHistoryOfAnItemWhoseAnnihilationIsAnnulledToPickUpAnySubsequentEventsRelatingToThatItem()
       : DynamicTests = {
     val itemId = "Fred"
@@ -3254,6 +3432,8 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
         }
     }
   }
+
+
 
 
 

--- a/src/test/scala/com/sageserpent/plutonium/WorldBehaviourAmericium.scala
+++ b/src/test/scala/com/sageserpent/plutonium/WorldBehaviourAmericium.scala
@@ -1071,6 +1071,82 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
   }
 
 @TestFactory
+  def notAllowTheHistoryToBeAlteredByIneffectiveEvents(): DynamicTests = {
+    val testCaseTrials = for {
+      recordingsGroupedById <- recordingsGroupedByIdTrials(
+        forbidAnnihilations = false
+      )
+      shuffledRecordings <-
+        shuffleRecordingsPreservingRelativeOrderOfEventsAtTheSameWhen(
+          recordingsGroupedById
+        )
+      bigShuffledHistoryOverLotsOfThings <- api
+        .splitsIntoNonEmptyPieces(shuffledRecordings.zipWithIndex)
+        .map(liftRecordings)
+      asOfs <- instantTrials
+        .listsOfSize(bigShuffledHistoryOverLotsOfThings.size)
+        .map(_.sorted)
+      queryWhen <- unboundedInstantTrials.filter(_ < PositiveInfinity)
+    } yield HistoryTestCase(
+      recordingsGroupedById,
+      bigShuffledHistoryOverLotsOfThings,
+      asOfs,
+      queryWhen
+    )
+
+    testCaseTrials.withLimit(200).dynamicTests {
+      case HistoryTestCase(
+            recordingsGroupedById,
+            bigShuffledHistoryOverLotsOfThings,
+            asOfs,
+            queryWhen
+          ) =>
+        Using.resource(makeWorld()) { world =>
+          recordEventsInWorld(
+            bigShuffledHistoryOverLotsOfThings,
+            asOfs,
+            world
+          )
+
+          for (
+            RecordingsNoLaterThan(
+              _,
+              _,
+              _,
+              ineffectiveEventFor,
+              _
+            ) <- recordingsGroupedById.flatMap(_.thePartNoLaterThan(queryWhen))
+          ) {
+            world.revise(
+              Map(-1 -> Some(ineffectiveEventFor(queryWhen))),
+              asOfs.last
+            )
+          }
+
+          val scope = world.scopeFor(queryWhen, world.nextRevision)
+
+          val checks = for {
+            recording <- recordingsGroupedById
+            RecordingsNoLaterThan(historyId, historiesFrom, _, _, _) <-
+              recording.thePartNoLaterThan(
+                queryWhen
+              )
+          } yield (historiesFrom, historyId)
+
+          if (checks.isEmpty) Trials.reject()
+
+          for ((historiesFrom, historyId) <- checks) {
+            withClue(s"Could not find a history for id: $historyId.") {
+              assert(historiesFrom(scope) match {
+                case Seq(_) => true
+              })
+            }
+          }
+        }
+    }
+  }
+
+@TestFactory
   def revealAllTheHistoryOfARelatedItemUpToTheWhenLimitOfAScopeMadeFromIt(): DynamicTests = {
     val testCaseTrials = for {
       referencedHistoryRecordingsGroupedById <-
@@ -2954,6 +3030,8 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
         }
     }
   }
+
+
 
 
 

--- a/src/test/scala/com/sageserpent/plutonium/WorldBehaviourAmericium.scala
+++ b/src/test/scala/com/sageserpent/plutonium/WorldBehaviourAmericium.scala
@@ -402,7 +402,7 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
 
   import cats.implicits._
 
-@TestFactory
+  @TestFactory
   def notContainAnyIdentifiables(): DynamicTests = {
     val scopeTrials = for {
       when <- unboundedInstantTrials
@@ -421,7 +421,7 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
     }
   }
 
-@Test
+  @Test
   def haveNoCurrentRevision(): Unit = {
     Using.resource(makeWorld()) { world =>
       withClue(
@@ -430,7 +430,7 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
     }
   }
 
-@TestFactory
+  @TestFactory
   def revealAllHistoryUpToTheAsOfLimitOfAScopeMadeFromIt(): DynamicTests = {
     val testCaseTrials: Trials[OrderedHistoryTestCase] = for {
       recordingsGroupedById <- recordingsGroupedByIdTrials(
@@ -541,7 +541,7 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
     }
   }
 
-@TestFactory
+  @TestFactory
   def notMysteriouslyFailToYieldItems(): DynamicTests = {
     val testCaseTrials = for {
       referringHistoryRecordingsGroupedById <-
@@ -597,7 +597,7 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
     }
   }
 
-@TestFactory
+  @TestFactory
   def deduceTheMostAccurateTypeForItemsBasedOnTheEventsThatReferToThem(): DynamicTests = {
     val testCaseTrials = for {
       fooHistoryIds <- fooHistoryIdTrials.map("Foo_" + _).nonEmptySets
@@ -700,7 +700,7 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
     }
   }
 
-@TestFactory
+  @TestFactory
   def revealTheSameLackOfHistoryFromAScopeWithAnAsOfLimitThatComesAtOrAfterThatRevisionButBeforeTheFollowingRevision()
       : DynamicTests = {
     val testCaseTrials = for {
@@ -793,7 +793,7 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
     }
   }
 
-@TestFactory
+  @TestFactory
   def revealTheSameHistoryFromAScopeWithAnAsOfLimitThatComesAtOrAfterThatRevisionButBeforeTheFollowingRevision()
       : DynamicTests = {
     val testCaseTrials = for {
@@ -877,7 +877,7 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
     }
   }
 
-@TestFactory
+  @TestFactory
   def revealTheSameNextRevisionFromAScopeWithAnAsOfLimitThatComesAtOrAfterThatRevisionButBeforeTheFollowingRevision()
       : DynamicTests = {
     val testCaseTrials = for {
@@ -959,7 +959,7 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
     }
   }
 
-@TestFactory
+  @TestFactory
   def notPermitAnInconsistentRevisionToBeMade(): DynamicTests = {
     val testCaseTrials: Trials[FaultyRevisionTestCase] = for {
       faultyRecordingsGroupedById <- faultyRecordingsGroupedByIdTrials
@@ -999,7 +999,7 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
     }
   }
 
-@TestFactory
+  @TestFactory
   def revealAllTheHistoryUpToTheWhenLimitOfAScopeMadeFromIt(): DynamicTests = {
     val testCaseTrials = for {
       recordingsGroupedById <- recordingsGroupedByIdTrials(
@@ -1068,7 +1068,7 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
     }
   }
 
-@TestFactory
+  @TestFactory
   def buildAnItemsStateInAMannerConsistentWithTheHistoryExperiencedByTheItemDueToEventsThatDefineChangesOnIt()
       : DynamicTests = {
     val itemId = "Fred"
@@ -1117,7 +1117,7 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
     }
   }
 
-@TestFactory
+  @TestFactory
   def allowAnItemToBeRenderedFromABitemporalIfTheWhenLimitOfTheScopeIncludesARelevantEventThatDefinesSaidItem()
       : DynamicTests = {
     val testCaseTrials = for {
@@ -1179,7 +1179,7 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
     }
   }
 
-@TestFactory
+  @TestFactory
   def notAllowTheHistoryToBeAlteredByIneffectiveEvents(): DynamicTests = {
     val testCaseTrials = for {
       recordingsGroupedById <- recordingsGroupedByIdTrials(
@@ -1255,7 +1255,7 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
     }
   }
 
-@TestFactory
+  @TestFactory
   def revealAllTheHistoryOfARelatedItemUpToTheWhenLimitOfAScopeMadeFromIt(): DynamicTests = {
     val testCaseTrials = for {
       referencedHistoryRecordingsGroupedById <-
@@ -1359,7 +1359,7 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
       }
   }
 
-@TestFactory
+  @TestFactory
   def yieldTheSameIdentityForARelatedItemAsWhenThatItemIsDirectlyQueriedFor(): DynamicTests = {
     val testCaseTrials = for {
       referencedHistoryRecordingsGroupedById <-
@@ -1475,7 +1475,7 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
       }
   }
 
-@TestFactory
+  @TestFactory
   def notRevealAnItemAtAQueryTimeComingBeforeItsFirstDefiningEvent(): DynamicTests = {
     val testCaseTrials = for {
       recordingsGroupedById <- recordingsGroupedByIdTrials(
@@ -1539,7 +1539,7 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
     }
   }
 
-@TestFactory
+  @TestFactory
   def notConsiderAnIneffectiveEventAsBeingDefining(): DynamicTests = {
     val testCaseTrials = for {
       recordingsGroupedById <- recordingsGroupedByIdTrials(
@@ -1628,7 +1628,7 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
     }
   }
 
-@TestFactory
+  @TestFactory
   def considerAReferenceToARelatedItemInAnEventAsBeingDefining(): DynamicTests = {
     val testCaseTrials = for {
       referencedHistoryRecordingsGroupedById <-
@@ -1716,7 +1716,7 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
       }
   }
 
-@TestFactory
+  @TestFactory
   def treatAnAnnihilatedItemAccessedViaAReferenceToARelatedItemAsBeingAGhost(): DynamicTests = {
     val testCaseTrials = for {
       referencedHistoryRecordingsGroupedById <-
@@ -1845,7 +1845,7 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
     }
   }
 
-@TestFactory
+  @TestFactory
   def notAllowAnEventToEitherReferToOrToMutateTheStateOfARelatedItemThatIsAGhost(): DynamicTests = {
     val testCaseTrials = for {
       referencedHistoryRecordingsGroupedById <-
@@ -1992,7 +1992,7 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
     }
   }
 
-@TestFactory
+  @TestFactory
   def notPermitTheAnnihilationOfAnItemAtAQueryTimeComingBeforeItsFirstDefiningEvent(): DynamicTests = {
     val testCaseTrials = for {
       recordingsGroupedById <- integerHistoryRecordingsGroupedByIdTrials
@@ -2072,7 +2072,7 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
     }
   }
 
-@TestFactory
+  @TestFactory
   def haveANextRevisionThatReflectsTheLastAddedRevision(): DynamicTests = {
     val testCaseTrials = for {
       recordingsGroupedById <- recordingsGroupedByIdTrials(
@@ -2116,7 +2116,7 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
     }
   }
 
-@TestFactory
+  @TestFactory
   def haveAVersionTimelineThatRecordsTheAsOfTimeForEachOfItsRevisions(): DynamicTests = {
     val testCaseTrials = for {
       recordingsGroupedById <- recordingsGroupedByIdTrials(
@@ -2160,7 +2160,7 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
     }
   }
 
-@TestFactory
+  @TestFactory
   def haveASortedVersionTimeline(): DynamicTests = {
     val testCaseTrials = for {
       recordingsGroupedById <- recordingsGroupedByIdTrials(
@@ -2206,7 +2206,7 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
     }
   }
 
-@TestFactory
+  @TestFactory
   def allocateRevisionNumbersSequentially(): DynamicTests = {
     val testCaseTrials = for {
       recordingsGroupedById <- recordingsGroupedByIdTrials(
@@ -2252,7 +2252,7 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
     }
   }
 
-@TestFactory
+  @TestFactory
   def haveANextRevisionNumberThatIsTheSizeOfItsVersionTimeline(): DynamicTests = {
     val testCaseTrials = for {
       recordingsGroupedById <- recordingsGroupedByIdTrials(
@@ -2296,7 +2296,7 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
     }
   }
 
-@TestFactory
+  @TestFactory
   def notPermitTheAsOfTimeForANewRevisionToBeLessThanThatOfAnyExistingRevision(): DynamicTests = {
     val testCaseTrials = for {
       recordingsGroupedById <- recordingsGroupedByIdTrials(
@@ -2363,7 +2363,7 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
     }
   }
 
-@TestFactory
+  @TestFactory
   def createAScopeWhosePropertiesRelateToTheCallToScopeForWhenUsingTheNextRevisionOverload(): DynamicTests = {
     val testCaseTrials = for {
       recordingsGroupedById <- recordingsGroupedByIdTrials(
@@ -2462,7 +2462,7 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
     }
   }
 
-@TestFactory
+  @TestFactory
   def createAScopeWhosePropertiesRelateToTheCallToScopeForWhenUsingTheAsOfTimeOverload(): DynamicTests = {
     val testCaseTrials = for {
       recordingsGroupedById <- recordingsGroupedByIdTrials(
@@ -2554,7 +2554,7 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
     }
   }
 
-@TestFactory
+  @TestFactory
   def createAScopeThatIsASnapshotUnaffectedBySubsequentRevisions(): DynamicTests = {
     val testCaseTrials = for {
       recordingsGroupedById <- recordingsGroupedByIdTrials(
@@ -2638,7 +2638,7 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
     }
   }
 
-@TestFactory
+  @TestFactory
   def createRevisionsWithTheStrongExceptionSafetyGuarantee(): DynamicTests = {
     val testCaseTrials = for {
       recordingsGroupedById <- nonConflictingRecordingsGroupedByIdTrials
@@ -2739,7 +2739,7 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
     }
   }
 
-@TestFactory
+  @TestFactory
   def yieldTheSameHistoriesForScopesIncludingAllChangesAtTheLatestRevisionRegardlessOfHowChangesAreGroupedIntoRevisions()
       : DynamicTests = {
     val testCaseTrials = for {
@@ -2826,7 +2826,7 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
     }
   }
 
-@TestFactory
+  @TestFactory
   def allowEventsToVaryInTheirViewOfTheTypeOfAnItemReferencedByAnId(): DynamicTests = {
     val testCaseTrials = for {
       recordingsGroupedById <- variablyTypedRecordingsGroupedByIdTrials
@@ -2899,7 +2899,7 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
     }
   }
 
-@TestFactory
+  @TestFactory
   def forbidRecordingOfEventsThatHaveInconsistentViewsOfTheTypeOfAnItemReferencedByAnId(): DynamicTests = {
     val testCaseTrials = for {
       recordingsGroupedById <- variablyTypedRecordingsGroupedByIdTrials
@@ -3036,7 +3036,7 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
     }
   }
 
-@TestFactory
+  @TestFactory
   def allowEventsToReferToAnItemViaAnAbstractTypeProvidedItIsDefinedConcretelyInOtherEvents()
       : DynamicTests = {
     val testCaseTrials = for {
@@ -3119,7 +3119,7 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
     }
   }
 
-@TestFactory
+  @TestFactory
   def allowEventsToReferToAnItemViaAConcreteTypeWhenItIsDefinedAbstractlyInOtherEvents()
       : DynamicTests = {
     val testCaseTrials = for {
@@ -3202,7 +3202,7 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
     }
   }
 
-@TestFactory
+  @TestFactory
   def recordBookingsFromEventsUsingAbstractTypesInTheSameMannerAsForConcreteTypes(): DynamicTests = {
     val testCaseTrials: Trials[MixedAbstractConcreteTestCase] = for {
       recordingsGroupedById <- mixedAbstractedAndImplementingRecordingsGroupedByIdTrials(
@@ -3292,7 +3292,7 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
     }
   }
 
-@TestFactory
+  @TestFactory
   def forbidTheBookingOfEventsThatOnlyEverReferToAnItemViaAnAbstractType(): DynamicTests = {
     val testCaseTrials = for {
       recordingsForAbstractedHistoriesGroupedById <-
@@ -3341,7 +3341,7 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
     }
   }
 
-@TestFactory
+  @TestFactory
   def takeIntoAccountThePreciseTypeOfTheItemReferencedByAnAnnihilationWhenOtherEventsReferToTheSameItemViaLooserTypes()
       : DynamicTests = {
     val testCaseTrials: Trials[PreciseTypeAnnihilationTestCase] = for {
@@ -3467,7 +3467,7 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
     }
   }
 
-@TestFactory
+  @TestFactory
   def reflectTheAbsenceOfAllItemsOfACompatibleTypeRelevantToAScopeThatShareAnIdFollowingAnAnnihilationUsingThatId()
       : DynamicTests = {
     val testCaseTrials = for {
@@ -3569,7 +3569,7 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
     }
   }
 
-@TestFactory
+  @TestFactory
   def extendTheHistoryOfAnItemWhoseAnnihilationIsAnnulledToPickUpAnySubsequentEventsRelatingToThatItem()
       : DynamicTests = {
     val itemId = "Fred"
@@ -3659,7 +3659,7 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
     }
   }
 
-@TestFactory
+  @TestFactory
   def buildAnItemStateInAMannerConsistentWithTheHistoryExperiencedByTheItemRegardlessOfAnyCorrectedHistory()
       : DynamicTests = {
     val itemId = "Fred"
@@ -3737,7 +3737,7 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
     }
   }
 
-@TestFactory
+  @TestFactory
   def buildAnItemStateInAMannerConsistentWithTheHistoryExperiencedByTheItemRegardlessOfAnyCorrectedHistoryWithATwist()
       : DynamicTests = {
     val itemId = "Fred"
@@ -3803,7 +3803,7 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
     }
   }
 
-@TestFactory
+  @TestFactory
   def buildAnItemStateInAMannerConsistentWithTheHistoryExperiencedByTheItemRegardlessOfAnyCorrectedHistoryWithAnotherTwist()
       : DynamicTests = {
     val itemId = "Fred"
@@ -3884,7 +3884,7 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
     }
   }
 
-@TestFactory
+  @TestFactory
   def yieldAHistoryAtTheFinalRevisionBasedOnlyOnTheLatestCorrections(): DynamicTests = {
     val testCaseTrials = for {
       recordingsGroupedById <- recordingsGroupedByIdTrials(
@@ -3960,7 +3960,7 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
     }
   }
 
-@TestFactory
+  @TestFactory
   def allowAnEntireHistoryToBeCompletelyAnnulledAndThenRewritten(): DynamicTests = {
     val testCaseTrials = for {
       recordingsGroupedById <- recordingsGroupedByIdTrials(
@@ -4074,7 +4074,7 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
     }
   }
 
-@TestFactory
+  @TestFactory
   def yieldAHistoryWhoseVersionsOfEventsReflectTheRevisionOfAScopeMadeFromIt(): DynamicTests = {
     val testCaseTrials = for {
       recordingsGroupedById <- recordingsGroupedByIdTrials(
@@ -4170,7 +4170,7 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
     }
   }
 
-@TestFactory
+  @TestFactory
   def yieldAHistoryWhoseVersionsOfEventsReflectArbitraryScopesMadeFromItAtVaryingRevisions(): DynamicTests = {
     val testCaseSubSectionTrials = for {
       recordingsGroupedById <- recordingsGroupedByIdTrials(
@@ -4354,7 +4354,7 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
     }
   }
 
-@TestFactory
+  @TestFactory
   def allowAnEntireHistoryToBeCompletelyAnnulledAndThenRewrittenAtTheSameAsOf(): DynamicTests = {
     val testCaseTrials = for {
       recordingsGroupedById <- recordingsGroupedByIdTrials(
@@ -4454,50 +4454,6 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
         }
     }
   }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
   abstract class NonExistentHistory extends History {
     override type Id = NonExistentId

--- a/src/test/scala/com/sageserpent/plutonium/WorldBehaviourAmericium.scala
+++ b/src/test/scala/com/sageserpent/plutonium/WorldBehaviourAmericium.scala
@@ -851,6 +851,46 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
   }
 
 @TestFactory
+  def notPermitAnInconsistentRevisionToBeMade(): DynamicTests = {
+    val testCaseTrials: Trials[FaultyRevisionTestCase] = for {
+      faultyRecordingsGroupedById <- faultyRecordingsGroupedByIdTrials
+      bigShuffledFaultyHistoryOverLotsOfThings <-
+        shuffleRecordingsPreservingRelativeOrderOfEventsAtTheSameWhen(
+          faultyRecordingsGroupedById
+        ).flatMap(shuffled => api.splitsIntoNonEmptyPieces(shuffled.zipWithIndex)).map(liftRecordings)
+      asOfs <- instantTrials
+        .listsOfSize(bigShuffledFaultyHistoryOverLotsOfThings.size)
+        .map(_.sorted)
+      queryWhen <- unboundedInstantTrials
+    } yield FaultyRevisionTestCase(
+      faultyRecordingsGroupedById,
+      bigShuffledFaultyHistoryOverLotsOfThings,
+      asOfs,
+      queryWhen
+    )
+
+    testCaseTrials.withLimit(200).dynamicTests {
+      case FaultyRevisionTestCase(
+            _,
+            bigShuffledFaultyHistoryOverLotsOfThings,
+            asOfs,
+            _
+          ) =>
+        Using.resource(makeWorld()) { world =>
+          assertThrows(
+            WorldSpecSupport.changeError.getClass,
+            () =>
+              recordEventsInWorld(
+                bigShuffledFaultyHistoryOverLotsOfThings,
+                asOfs,
+                world
+              )
+          )
+        }
+    }
+  }
+
+@TestFactory
   def revealAllTheHistoryUpToTheWhenLimitOfAScopeMadeFromIt(): DynamicTests = {
     val testCaseTrials = for {
       recordingsGroupedById <- recordingsGroupedByIdTrials(
@@ -2803,6 +2843,8 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
         }
     }
   }
+
+
 
 
 

--- a/src/test/scala/com/sageserpent/plutonium/WorldBehaviourAmericium.scala
+++ b/src/test/scala/com/sageserpent/plutonium/WorldBehaviourAmericium.scala
@@ -2718,6 +2718,79 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
   }
 
 @TestFactory
+  def allowEventsToVaryInTheirViewOfTheTypeOfAnItemReferencedByAnId(): DynamicTests = {
+    val testCaseTrials = for {
+      recordingsGroupedById <- variablyTypedRecordingsGroupedByIdTrials
+      obsoleteRecordingsGroupedById <-
+        nonConflictingRecordingsGroupedByIdTrials
+      shuffledRecordings <-
+        shuffleRecordingsPreservingRelativeOrderOfEventsAtTheSameWhen(
+          recordingsGroupedById
+        )
+      shuffledObsoleteRecordings <-
+        shuffleRecordingsPreservingRelativeOrderOfEventsAtTheSameWhen(
+          obsoleteRecordingsGroupedById
+        )
+      bigShuffledHistoryOverLotsOfThings <- intersperseObsoleteEventsAmericium(
+        shuffledRecordings,
+        shuffledObsoleteRecordings
+      )
+      asOfs <- instantTrials
+        .listsOfSize(bigShuffledHistoryOverLotsOfThings.size)
+        .map(_.sorted)
+    } yield HistoryTestCase(
+      recordingsGroupedById,
+      bigShuffledHistoryOverLotsOfThings,
+      asOfs,
+      PositiveInfinity
+    )
+
+    testCaseTrials.withLimit(200).dynamicTests {
+      case HistoryTestCase(
+            recordingsGroupedById,
+            bigShuffledHistoryOverLotsOfThings,
+            asOfs,
+            queryWhen
+          ) =>
+        Using.resource(makeWorld()) { world =>
+          recordEventsInWorld(
+            bigShuffledHistoryOverLotsOfThings,
+            asOfs,
+            world
+          )
+
+          val scope = world.scopeFor(queryWhen, world.nextRevision)
+
+          val checks = for {
+            recording <- recordingsGroupedById
+            RecordingsNoLaterThan(
+              historyId,
+              historiesFrom,
+              pertinentRecordings,
+              _,
+              _
+            ) <- recording.thePartNoLaterThan(
+              queryWhen
+            )
+            Seq(history) = historiesFrom(scope)
+          } yield (
+            historyId,
+            history.datums,
+            pertinentRecordings.map(_._1)
+          )
+
+          if (checks.isEmpty) Trials.reject()
+
+          for ((historyId, actualHistory, expectedHistory) <- checks) {
+            withClue(s"History mismatch for history id: $historyId.") {
+              assert(actualHistory == expectedHistory)
+            }
+          }
+        }
+    }
+  }
+
+@TestFactory
   def extendTheHistoryOfAnItemWhoseAnnihilationIsAnnulledToPickUpAnySubsequentEventsRelatingToThatItem()
       : DynamicTests = {
     val itemId = "Fred"
@@ -3030,6 +3103,8 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
         }
     }
   }
+
+
 
 
 

--- a/src/test/scala/com/sageserpent/plutonium/WorldBehaviourAmericium.scala
+++ b/src/test/scala/com/sageserpent/plutonium/WorldBehaviourAmericium.scala
@@ -322,90 +322,6 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
   }
 
 @TestFactory
-  def revealTheSameHistoryFromAScopeWithAnAsOfLimitThatComesAtOrAfterThatRevisionButBeforeTheFollowingRevision()
-      : DynamicTests = {
-    val testCaseTrials = for {
-      recordingsGroupedById <- recordingsGroupedByIdTrials(
-        forbidAnnihilations = false
-      )
-      shuffledRecordings <-
-        shuffleRecordingsPreservingRelativeOrderOfEventsAtTheSameWhen(
-          recordingsGroupedById
-        )
-      bigShuffledHistoryOverLotsOfThings <- api
-        .splitsIntoNonEmptyPieces(shuffledRecordings.zipWithIndex)
-        .map(liftRecordings)
-      asOfs <- instantTrials
-        .listsOfSize(bigShuffledHistoryOverLotsOfThings.size)
-        .map(_.sorted)
-      queryWhen <- unboundedInstantTrials
-      laterAsOfs <- api.sequences(asOfs.zip(asOfs.tail :+ asOfs.last.plusSeconds(10L)).map {
-        case (earlier, later) if earlier isBefore later =>
-          api.longs(earlier.getEpochSecond, later.getEpochSecond - 1).map(Instant.ofEpochSecond).filter(_ isAfter earlier)
-        case (earlier, _) => api.only(earlier)
-      })
-    } yield HistoryConsistencyTestCase(
-      recordingsGroupedById,
-      bigShuffledHistoryOverLotsOfThings,
-      asOfs,
-      queryWhen,
-      laterAsOfs
-    )
-
-    testCaseTrials.withLimit(200).dynamicTests {
-      case HistoryConsistencyTestCase(
-            recordingsGroupedById,
-            bigShuffledHistoryOverLotsOfThings,
-            asOfs,
-            queryWhen,
-            laterAsOfs
-          ) =>
-        Using.resource(makeWorld()) { world =>
-          val revisions = recordEventsInWorld(
-            bigShuffledHistoryOverLotsOfThings,
-            asOfs,
-            world
-          )
-
-          val checks = for {
-            (
-              (earlierAsOfCorrespondingToRevision, revision),
-              laterAsOfSharingTheSameRevisionAsTheEarlierOne
-            ) <- asOfs zip revisions zip laterAsOfs
-            if earlierAsOfCorrespondingToRevision isBefore laterAsOfSharingTheSameRevisionAsTheEarlierOne
-
-            baselineScope = world
-              .scopeFor(queryWhen, earlierAsOfCorrespondingToRevision)
-            scopeForLaterAsOfSharingTheSameRevisionAsTheEarlierOne =
-              world
-                .scopeFor(
-                  queryWhen,
-                  laterAsOfSharingTheSameRevisionAsTheEarlierOne
-                )
-            recording <- recordingsGroupedById
-            RecordingsNoLaterThan(historyId, historiesFrom, _, _, _) <-
-              recording.thePartNoLaterThan(
-                queryWhen
-              )
-            if historiesFrom(baselineScope).nonEmpty
-            Seq(baselineHistory) = historiesFrom(baselineScope)
-            Seq(historyUnderTest) = historiesFrom(
-              scopeForLaterAsOfSharingTheSameRevisionAsTheEarlierOne
-            )
-          } yield (historyId, baselineHistory.datums, historyUnderTest.datums)
-
-          if (checks.isEmpty) Trials.reject()
-
-          for ((historyId, baselineDatums, testDatums) <- checks) {
-            withClue(s"For history id: $historyId.") {
-              assert(baselineDatums == testDatums)
-            }
-          }
-        }
-    }
-  }
-
-  @TestFactory
   def revealAllHistoryUpToTheAsOfLimitOfAScopeMadeFromIt(): DynamicTests = {
     val testCaseTrials: Trials[OrderedHistoryTestCase] = for {
       recordingsGroupedById <- recordingsGroupedByIdTrials(
@@ -762,6 +678,90 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
                   scopeForLaterAsOfSharingTheSameRevisionAsTheEarlierOne
                 ).isEmpty
               )
+            }
+          }
+        }
+    }
+  }
+
+@TestFactory
+  def revealTheSameHistoryFromAScopeWithAnAsOfLimitThatComesAtOrAfterThatRevisionButBeforeTheFollowingRevision()
+      : DynamicTests = {
+    val testCaseTrials = for {
+      recordingsGroupedById <- recordingsGroupedByIdTrials(
+        forbidAnnihilations = false
+      )
+      shuffledRecordings <-
+        shuffleRecordingsPreservingRelativeOrderOfEventsAtTheSameWhen(
+          recordingsGroupedById
+        )
+      bigShuffledHistoryOverLotsOfThings <- api
+        .splitsIntoNonEmptyPieces(shuffledRecordings.zipWithIndex)
+        .map(liftRecordings)
+      asOfs <- instantTrials
+        .listsOfSize(bigShuffledHistoryOverLotsOfThings.size)
+        .map(_.sorted)
+      queryWhen <- unboundedInstantTrials
+      laterAsOfs <- api.sequences(asOfs.zip(asOfs.tail :+ asOfs.last.plusSeconds(10L)).map {
+        case (earlier, later) if earlier isBefore later =>
+          api.longs(earlier.getEpochSecond, later.getEpochSecond - 1).map(Instant.ofEpochSecond).filter(_ isAfter earlier)
+        case (earlier, _) => api.only(earlier)
+      })
+    } yield HistoryConsistencyTestCase(
+      recordingsGroupedById,
+      bigShuffledHistoryOverLotsOfThings,
+      asOfs,
+      queryWhen,
+      laterAsOfs
+    )
+
+    testCaseTrials.withLimit(200).dynamicTests {
+      case HistoryConsistencyTestCase(
+            recordingsGroupedById,
+            bigShuffledHistoryOverLotsOfThings,
+            asOfs,
+            queryWhen,
+            laterAsOfs
+          ) =>
+        Using.resource(makeWorld()) { world =>
+          val revisions = recordEventsInWorld(
+            bigShuffledHistoryOverLotsOfThings,
+            asOfs,
+            world
+          )
+
+          val checks = for {
+            (
+              (earlierAsOfCorrespondingToRevision, revision),
+              laterAsOfSharingTheSameRevisionAsTheEarlierOne
+            ) <- asOfs zip revisions zip laterAsOfs
+            if earlierAsOfCorrespondingToRevision isBefore laterAsOfSharingTheSameRevisionAsTheEarlierOne
+
+            baselineScope = world
+              .scopeFor(queryWhen, earlierAsOfCorrespondingToRevision)
+            scopeForLaterAsOfSharingTheSameRevisionAsTheEarlierOne =
+              world
+                .scopeFor(
+                  queryWhen,
+                  laterAsOfSharingTheSameRevisionAsTheEarlierOne
+                )
+            recording <- recordingsGroupedById
+            RecordingsNoLaterThan(historyId, historiesFrom, _, _, _) <-
+              recording.thePartNoLaterThan(
+                queryWhen
+              )
+            if historiesFrom(baselineScope).nonEmpty
+            Seq(baselineHistory) = historiesFrom(baselineScope)
+            Seq(historyUnderTest) = historiesFrom(
+              scopeForLaterAsOfSharingTheSameRevisionAsTheEarlierOne
+            )
+          } yield (historyId, baselineHistory.datums, historyUnderTest.datums)
+
+          if (checks.isEmpty) Trials.reject()
+
+          for ((historyId, baselineDatums, testDatums) <- checks) {
+            withClue(s"For history id: $historyId.") {
+              assert(baselineDatums == testDatums)
             }
           }
         }
@@ -2721,6 +2721,8 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
         }
     }
   }
+
+
 
 
 

--- a/src/test/scala/com/sageserpent/plutonium/WorldBehaviourAmericium.scala
+++ b/src/test/scala/com/sageserpent/plutonium/WorldBehaviourAmericium.scala
@@ -4254,7 +4254,7 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
                     asOfs
                   ) :: remainingSubsections =>
                 val sortedEventIds =
-                  (bigShuffledHistoryOverLotsOfThings.flatMap(_.map(_._2))).sorted.distinct
+                  bigShuffledHistoryOverLotsOfThings.flatMap(_.map(_._2)).sorted.distinct
                 assert(0 == sortedEventIds.head)
                 assert((sortedEventIds zip sortedEventIds.tail).forall {
                   case (first, second) => 1 + first == second
@@ -4269,17 +4269,11 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
                   )
                 val asOfForAnnulments = asOfs.head
                 try {
-                  if (world.revisionAsOfs.nonEmpty && asOfForAnnulments.isBefore(world.revisionAsOfs.last)) {
-                    throw new RuntimeException("Inconsistent asOf for annulments")
-                  }
                   recordEventsInWorld(
                     annulmentsForExtraEventIdsNotCorrectedInThisSubsection,
                     List(asOfForAnnulments),
                     world
                   )
-                  if (asOfs.nonEmpty && asOfs.head.isBefore(world.revisionAsOfs.last)) {
-                    throw new RuntimeException("Inconsistent asOf for history")
-                  }
                   recordEventsInWorld(
                     bigShuffledHistoryOverLotsOfThings,
                     asOfs.toList,

--- a/src/test/scala/com/sageserpent/plutonium/WorldBehaviourAmericium.scala
+++ b/src/test/scala/com/sageserpent/plutonium/WorldBehaviourAmericium.scala
@@ -293,7 +293,7 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
 
   import cats.implicits._
 
-  @TestFactory
+@TestFactory
   def worldWithNoHistory(): DynamicTests = {
     val scopeTrials = for {
       when <- unboundedInstantTrials
@@ -312,326 +312,96 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
     }
   }
 
-  @TestFactory
-  def buildAnItemStateInAMannerConsistentWithTheHistoryExperiencedByTheItemRegardlessOfAnyCorrectedHistory()
-      : DynamicTests = {
-    val itemId = "Fred"
-
-    val testCaseTrials = for {
-      eventTimes <- instantTrials.nonEmptyLists.map(_.sorted)
-      steps = 1 to eventTimes.size
-      recordings: List[(Unbounded[Instant], Event)] =
-        eventTimes.zip(steps).map { case (when, step) =>
-          Finite(when) -> Change
-            .forOneItem[IntegerHistory](when)(
-              itemId,
-              { item: IntegerHistory =>
-                item.integerProperty = step
-              }
-            )
-        }
-      obsoleteEventTimes <- instantTrials.nonEmptyLists
-      obsoleteSteps = 1 to obsoleteEventTimes.size
-      obsoleteRecordings: List[(Unbounded[Instant], Event)] =
-        obsoleteEventTimes.zip(obsoleteSteps).map { case (when, step) =>
-          Finite(when) -> Change
-            .forOneItem[IntegerHistory](when)(
-              itemId,
-              { item: IntegerHistory =>
-                item.integerProperty = step
-              }
-            )
-        }
-      shuffledRecordings <-
-        shuffleRecordingsPreservingRelativeOrderOfEventsAtTheSameWhenForAGivenItem(
-          recordings
-        )
-      shuffledObsoleteRecordings <-
-        shuffleRecordingsPreservingRelativeOrderOfEventsAtTheSameWhenForAGivenItem(
-          obsoleteRecordings
-        )
-      bigShuffledHistoryOverLotsOfThings <-
-        intersperseObsoleteEventsAmericium(
-          shuffledRecordings,
-          shuffledObsoleteRecordings
-        )
-      asOfs <- instantTrials
-        .listsOfSize(bigShuffledHistoryOverLotsOfThings.size)
-        .map(_.sorted)
-    } yield StateConsistencyTestCase(
-      bigShuffledHistoryOverLotsOfThings,
-      asOfs,
-      steps
-    )
-
-    testCaseTrials.withLimit(200).dynamicTests {
-      case StateConsistencyTestCase(
-            bigShuffledHistoryOverLotsOfThings,
-            asOfs,
-            steps
-          ) =>
-        Using.resource(makeWorld()) { world =>
-          recordEventsInWorld(
-            bigShuffledHistoryOverLotsOfThings,
-            asOfs,
-            world
-          )
-
-          val scope =
-            world
-              .scopeFor(PositiveInfinity, world.nextRevision)
-
-          val fredTheItem = scope
-            .render(Bitemporal.withId[IntegerHistory](itemId))
-            .toList
-
-          assert(steps == fredTheItem.head.datums)
-        }
-    }
-  }
-
-  @TestFactory
-  def buildAnItemStateInAMannerConsistentWithTheHistoryExperiencedByTheItemRegardlessOfAnyCorrectedHistoryWithATwist()
-      : DynamicTests = {
-    val itemId = "Fred"
-
-    val testCaseTrials = for {
-      eventTimes <- instantTrials.nonEmptyLists.map(_.sorted)
-      steps = 1 to eventTimes.size
-      recordings: List[(Unbounded[Instant], Event)] =
-        eventTimes.zip(steps).map { case (when, step) =>
-          Finite(when) -> Change
-            .forOneItem[IntegerHistory](when)(
-              itemId,
-              { item: IntegerHistory =>
-                item.integerProperty = step
-              }
-            )
-        }
-      shuffledRecordings <-
-        shuffleRecordingsPreservingRelativeOrderOfEventsAtTheSameWhenForAGivenItem(
-          recordings
-        )
-      shuffledObsoleteRecordings <-
-        shuffleRecordingsPreservingRelativeOrderOfEventsAtTheSameWhenForAGivenItem(
-          recordings
-        )
-      bigShuffledHistoryOverLotsOfThings <-
-        intersperseObsoleteEventsAmericium(
-          shuffledRecordings,
-          shuffledObsoleteRecordings
-        )
-      asOfs <- instantTrials
-        .listsOfSize(bigShuffledHistoryOverLotsOfThings.size)
-        .map(_.sorted)
-    } yield StateConsistencyTestCase(
-      bigShuffledHistoryOverLotsOfThings,
-      asOfs,
-      steps
-    )
-
-    testCaseTrials.withLimit(200).dynamicTests {
-      case StateConsistencyTestCase(
-            bigShuffledHistoryOverLotsOfThings,
-            asOfs,
-            steps
-          ) =>
-        Using.resource(makeWorld()) { world =>
-          recordEventsInWorld(
-            bigShuffledHistoryOverLotsOfThings,
-            asOfs,
-            world
-          )
-
-          val scope =
-            world
-              .scopeFor(PositiveInfinity, world.nextRevision)
-
-          val fredTheItem = scope
-            .render(Bitemporal.withId[IntegerHistory](itemId))
-            .toList
-
-          assert(steps == fredTheItem.head.datums)
-        }
-    }
-  }
-
-  @TestFactory
-  def buildAnItemStateInAMannerConsistentWithTheHistoryExperiencedByTheItemRegardlessOfAnyCorrectedHistoryWithAnotherTwist()
-      : DynamicTests = {
-    val itemId = "Fred"
-
-    val testCaseTrials = for {
-      eventTimes <- api
-        .integers(0, 50)
-        .map(0 to _ toList)
-        .map(
-          _.map(timeInSeconds =>
-            Instant.ofEpochSecond(24 * 60 * 60 * timeInSeconds)
-          )
-        )
-      steps = 1 to eventTimes.size
-      recordings: List[(Unbounded[Instant], Event)] =
-        eventTimes.zip(steps).map { case (when, step) =>
-          Finite(when) -> Change
-            .forOneItem[IntegerHistory](when)(
-              itemId,
-              { item: IntegerHistory =>
-                item.integerProperty = step
-              }
-            )
-        }
-      shuffledObsoleteEventTimes <- api.shuffles(eventTimes)
-      obsoleteSteps = 1 to shuffledObsoleteEventTimes.size
-      obsoleteRecordings: List[(Unbounded[Instant], Event)] =
-        shuffledObsoleteEventTimes.zip(obsoleteSteps).map { case (when, step) =>
-          Finite(when) -> Change
-            .forOneItem[IntegerHistory](when)(
-              itemId,
-              { item: IntegerHistory =>
-                item.integerProperty = step
-              }
-            )
-        }
-
-      pairsOfObsoleteAndSucceedingEvents =
-        obsoleteRecordings.zipWithIndex.zip(recordings.zipWithIndex)
-
-      historyOverLotsOfThings = pairsOfObsoleteAndSucceedingEvents
-        .flatMap { case (obsolete, succeeding) =>
-          Seq(Seq(obsolete), Seq(succeeding))
-        }
-
-      asOfs <- instantTrials
-        .listsOfSize(historyOverLotsOfThings.length)
-        .map(_.sorted)
-    } yield StateConsistencyTestCase(
-      liftRecordings(historyOverLotsOfThings),
-      asOfs,
-      steps
-    )
-
-    testCaseTrials.withLimit(200).dynamicTests {
-      case StateConsistencyTestCase(
-            historyOverLotsOfThings,
-            asOfs,
-            steps
-          ) =>
-        Using.resource(makeWorld()) { world =>
-          recordEventsInWorld(
-            historyOverLotsOfThings,
-            asOfs,
-            world
-          )
-
-          val scope =
-            world
-              .scopeFor(PositiveInfinity, world.nextRevision)
-
-          val fredTheItem = scope
-            .render(Bitemporal.withId[IntegerHistory](itemId))
-            .toList
-
-          assert(steps.toSet == fredTheItem.head.datums.toSet)
-        }
-    }
-  }
-
-  @TestFactory
-  def extendTheHistoryOfAnItemWhoseAnnihilationIsAnnulledToPickUpAnySubsequentEventsRelatingToThatItem()
-      : DynamicTests = {
-    val itemId = "Fred"
-
-    val testCaseTrials = for {
-      eventTimes <- instantTrials.nonEmptyLists.map(_.sorted)
-      annihilationWhen <- instantTrials.filter(when =>
-        when.isAfter(eventTimes.head) && !when.isAfter(eventTimes.last)
-      )
-      steps = 1 to eventTimes.size
-      recordings: List[(Unbounded[Instant], Event)] =
-        eventTimes.zip(steps).map { case (when, step) =>
-          Finite(when) -> Change
-            .forOneItem[IntegerHistory](when)(
-              itemId,
-              { item: IntegerHistory =>
-                item.integerProperty = step
-              }
-            )
-        }
-      shuffledRecordings <-
-        shuffleRecordingsPreservingRelativeOrderOfEventsAtTheSameWhenForAGivenItem(
-          recordings
-        )
-      bigShuffledHistoryOverLotsOfThings <- api
-        .splitsIntoNonEmptyPieces(shuffledRecordings.zipWithIndex)
-      asOfs <- instantTrials
-        .listsOfSize(bigShuffledHistoryOverLotsOfThings.size)
-        .map(_.sorted)
-    } yield AnnulledAnnihilationTestCase(
-      liftRecordings(bigShuffledHistoryOverLotsOfThings),
-      asOfs,
-      steps,
-      annihilationWhen
-    )
-
-    testCaseTrials.withLimit(200).dynamicTests {
-      case AnnulledAnnihilationTestCase(
-            bigShuffledHistoryOverLotsOfThings,
-            asOfs,
-            steps,
-            annihilationWhen
-          ) =>
-        Using.resource(makeWorld()) { world =>
-          val initialEventId = -2
-
-          world.revise(
-            initialEventId,
-            Change.forOneItem[IntegerHistory](annihilationWhen)(
-              itemId,
-              { item: IntegerHistory =>
-                item.integerProperty = -1
-              }
-            ),
-            asOfs.head
-          )
-
-          val annihilationEventId = -1
-
-          world.revise(
-            annihilationEventId,
-            Annihilation[Any](annihilationWhen, itemId),
-            asOfs.head
-          )
-
-          recordEventsInWorld(
-            bigShuffledHistoryOverLotsOfThings,
-            asOfs,
-            world
-          )
-
-          world.annul(initialEventId, asOfs.last)
-
-          world.annul(annihilationEventId, asOfs.last)
-
-          val scope =
-            world
-              .scopeFor(PositiveInfinity, world.nextRevision)
-
-          val fredTheItem = scope
-            .render(Bitemporal.withId[IntegerHistory](itemId))
-            .toList
-
-          assert(steps == fredTheItem.head.datums)
-        }
-    }
-  }
-
-  @Test
+@Test
   def haveNoCurrentRevision(): Unit = {
     Using.resource(makeWorld()) { world =>
       withClue(
         s"Initial revision of a world ${world.nextRevision} should be: ${World.initialRevision}."
       )(assert(World.initialRevision == world.nextRevision))
+    }
+  }
+
+@TestFactory
+  def revealTheSameHistoryFromAScopeWithAnAsOfLimitThatComesAtOrAfterThatRevisionButBeforeTheFollowingRevision()
+      : DynamicTests = {
+    val testCaseTrials = for {
+      recordingsGroupedById <- recordingsGroupedByIdTrials(
+        forbidAnnihilations = false
+      )
+      shuffledRecordings <-
+        shuffleRecordingsPreservingRelativeOrderOfEventsAtTheSameWhen(
+          recordingsGroupedById
+        )
+      bigShuffledHistoryOverLotsOfThings <- api
+        .splitsIntoNonEmptyPieces(shuffledRecordings.zipWithIndex)
+        .map(liftRecordings)
+      asOfs <- instantTrials
+        .listsOfSize(bigShuffledHistoryOverLotsOfThings.size)
+        .map(_.sorted)
+      queryWhen <- unboundedInstantTrials
+      laterAsOfs <- api.sequences(asOfs.zip(asOfs.tail :+ asOfs.last.plusSeconds(10L)).map {
+        case (earlier, later) if earlier isBefore later =>
+          api.longs(earlier.getEpochSecond, later.getEpochSecond - 1).map(Instant.ofEpochSecond).filter(_ isAfter earlier)
+        case (earlier, _) => api.only(earlier)
+      })
+    } yield HistoryConsistencyTestCase(
+      recordingsGroupedById,
+      bigShuffledHistoryOverLotsOfThings,
+      asOfs,
+      queryWhen,
+      laterAsOfs
+    )
+
+    testCaseTrials.withLimit(200).dynamicTests {
+      case HistoryConsistencyTestCase(
+            recordingsGroupedById,
+            bigShuffledHistoryOverLotsOfThings,
+            asOfs,
+            queryWhen,
+            laterAsOfs
+          ) =>
+        Using.resource(makeWorld()) { world =>
+          val revisions = recordEventsInWorld(
+            bigShuffledHistoryOverLotsOfThings,
+            asOfs,
+            world
+          )
+
+          val checks = for {
+            (
+              (earlierAsOfCorrespondingToRevision, revision),
+              laterAsOfSharingTheSameRevisionAsTheEarlierOne
+            ) <- asOfs zip revisions zip laterAsOfs
+            if earlierAsOfCorrespondingToRevision isBefore laterAsOfSharingTheSameRevisionAsTheEarlierOne
+
+            baselineScope = world
+              .scopeFor(queryWhen, earlierAsOfCorrespondingToRevision)
+            scopeForLaterAsOfSharingTheSameRevisionAsTheEarlierOne =
+              world
+                .scopeFor(
+                  queryWhen,
+                  laterAsOfSharingTheSameRevisionAsTheEarlierOne
+                )
+            recording <- recordingsGroupedById
+            RecordingsNoLaterThan(historyId, historiesFrom, _, _, _) <-
+              recording.thePartNoLaterThan(
+                queryWhen
+              )
+            if historiesFrom(baselineScope).nonEmpty
+            Seq(baselineHistory) = historiesFrom(baselineScope)
+            Seq(historyUnderTest) = historiesFrom(
+              scopeForLaterAsOfSharingTheSameRevisionAsTheEarlierOne
+            )
+          } yield (historyId, baselineHistory.datums, historyUnderTest.datums)
+
+          if (checks.isEmpty) Trials.reject()
+
+          for ((historyId, baselineDatums, testDatums) <- checks) {
+            withClue(s"For history id: $historyId.") {
+              assert(baselineDatums == testDatums)
+            }
+          }
+        }
     }
   }
 
@@ -746,7 +516,63 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
     }
   }
 
-  @TestFactory
+@TestFactory
+  def notMysteriouslyFailToYieldItems(): DynamicTests = {
+    val testCaseTrials = for {
+      referringHistoryRecordingsGroupedById <-
+        referringHistoryRecordingsGroupedByIdTrials()
+      shuffledRecordings <- shuffleRecordingsPreservingRelativeOrderOfEventsAtTheSameWhen(
+        referringHistoryRecordingsGroupedById
+      )
+      bigShuffledHistoryOverLotsOfThings <- api.splitsIntoNonEmptyPieces(shuffledRecordings.zipWithIndex)
+      asOfs <- instantTrials.listsOfSize(bigShuffledHistoryOverLotsOfThings.size).map(_.sorted)
+      queryWhen <- unboundedInstantTrials
+    } yield HistoryTestCase(
+      referringHistoryRecordingsGroupedById,
+      liftRecordings(bigShuffledHistoryOverLotsOfThings),
+      asOfs,
+      queryWhen
+    )
+
+    testCaseTrials.withLimit(200).dynamicTests {
+      case HistoryTestCase(
+        referringHistoryRecordingsGroupedById,
+        bigShuffledHistoryOverLotsOfThings,
+        asOfs,
+        queryWhen
+      ) =>
+        Using.resource(makeWorld()) { world =>
+          recordEventsInWorld(
+            bigShuffledHistoryOverLotsOfThings,
+            asOfs,
+            world
+          )
+
+          val scope = world.scopeFor(queryWhen, world.nextRevision)
+
+          val checks = (for {
+            recording <- referringHistoryRecordingsGroupedById
+            RecordingsNoLaterThan(
+              referringHistoryId,
+              referringHistoriesFrom,
+              _,
+              _,
+              _
+            ) <- recording.thePartNoLaterThan(queryWhen)
+          } yield referringHistoryId -> referringHistoriesFrom(scope))
+
+          if (checks.isEmpty) Trials.reject()
+
+          for ((id, itemSingletonSequence) <- checks) {
+            withClue(s"Expected there to be a single item for id: $id.")(
+              assert(1 == itemSingletonSequence.size)
+            )
+          }
+        }
+    }
+  }
+
+@TestFactory
   def deduceTheMostAccurateTypeForItemsBasedOnTheEventsThatReferToThem(): DynamicTests = {
     val testCaseTrials = for {
       fooHistoryIds <- fooHistoryIdTrials.map("Foo_" + _).nonEmptySets
@@ -849,7 +675,7 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
     }
   }
 
-  @TestFactory
+@TestFactory
   def revealTheSameLackOfHistoryFromAScopeWithAnAsOfLimitThatComesAtOrAfterThatRevisionButBeforeTheFollowingRevision()
       : DynamicTests = {
     val testCaseTrials = for {
@@ -942,7 +768,7 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
     }
   }
 
-  @TestFactory
+@TestFactory
   def revealAllTheHistoryUpToTheWhenLimitOfAScopeMadeFromIt(): DynamicTests = {
     val testCaseTrials = for {
       recordingsGroupedById <- recordingsGroupedByIdTrials(
@@ -1011,64 +837,7 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
     }
   }
 
-  @TestFactory
-  def notMysteriouslyFailToYieldItems(): DynamicTests = {
-    val testCaseTrials = for {
-      referringHistoryRecordingsGroupedById <-
-        referringHistoryRecordingsGroupedByIdTrials()
-      shuffledRecordings <- shuffleRecordingsPreservingRelativeOrderOfEventsAtTheSameWhen(
-        referringHistoryRecordingsGroupedById
-      )
-      bigShuffledHistoryOverLotsOfThings <- api.splitsIntoNonEmptyPieces(shuffledRecordings.zipWithIndex)
-      asOfs <- instantTrials.listsOfSize(bigShuffledHistoryOverLotsOfThings.size).map(_.sorted)
-      queryWhen <- unboundedInstantTrials
-    } yield HistoryTestCase(
-      referringHistoryRecordingsGroupedById,
-      liftRecordings(bigShuffledHistoryOverLotsOfThings),
-      asOfs,
-      queryWhen
-    )
-
-    testCaseTrials.withLimit(200).dynamicTests {
-      case HistoryTestCase(
-        referringHistoryRecordingsGroupedById,
-        bigShuffledHistoryOverLotsOfThings,
-        asOfs,
-        queryWhen
-      ) =>
-        Using.resource(makeWorld()) { world =>
-          recordEventsInWorld(
-            bigShuffledHistoryOverLotsOfThings,
-            asOfs,
-            world
-          )
-
-          val scope = world.scopeFor(queryWhen, world.nextRevision)
-
-          val checks = (for {
-            recording <- referringHistoryRecordingsGroupedById
-            RecordingsNoLaterThan(
-              referringHistoryId,
-              referringHistoriesFrom,
-              _,
-              _,
-              _
-            ) <- recording.thePartNoLaterThan(queryWhen)
-          } yield referringHistoryId -> referringHistoriesFrom(scope))
-
-          if (checks.isEmpty) Trials.reject()
-
-          for ((id, itemSingletonSequence) <- checks) {
-            withClue(s"Expected there to be a single item for id: $id.")(
-              assert(1 == itemSingletonSequence.size)
-            )
-          }
-        }
-    }
-  }
-
-
-  @TestFactory
+@TestFactory
   def revealAllTheHistoryOfARelatedItemUpToTheWhenLimitOfAScopeMadeFromIt(): DynamicTests = {
     val testCaseTrials = for {
       referencedHistoryRecordingsGroupedById <-
@@ -1172,95 +941,7 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
       }
   }
 
-  @TestFactory
-  def considerAReferenceToARelatedItemInAnEventAsBeingDefining(): DynamicTests = {
-    val testCaseTrials = for {
-      referencedHistoryRecordingsGroupedById <-
-        referencedHistoryRecordingsGroupedByIdTrials(
-          forbidAnnihilations = false
-        )
-      referringHistoryRecordingsGroupedById <-
-        referringHistoryRecordingsGroupedByIdTrials()
-      obsoleteRecordingsGroupedById <-
-        nonConflictingRecordingsGroupedByIdTrials
-      shuffledRecordings <- shuffleRecordingsPreservingRelativeOrderOfEventsAtTheSameWhen(
-        referencedHistoryRecordingsGroupedById ++ referringHistoryRecordingsGroupedById
-      )
-      shuffledObsoleteRecordings <- shuffleRecordingsPreservingRelativeOrderOfEventsAtTheSameWhen(
-        obsoleteRecordingsGroupedById
-      )
-      bigShuffledHistoryOverLotsOfThings <- intersperseObsoleteEventsAmericium(
-        shuffledRecordings,
-        shuffledObsoleteRecordings
-      )
-      asOfs <- instantTrials
-        .listsOfSize(bigShuffledHistoryOverLotsOfThings.size)
-        .map(_.sorted)
-      queryWhen <- unboundedInstantTrials
-    } yield RelatedItemTestCase(
-      referencedHistoryRecordingsGroupedById,
-      referringHistoryRecordingsGroupedById,
-      bigShuffledHistoryOverLotsOfThings,
-      asOfs,
-      queryWhen
-    )
-    testCaseTrials
-      .withStrategy(_ => CasesLimitStrategy.counted(200, 20))
-      .dynamicTests {
-        case RelatedItemTestCase(
-              referencedHistoryRecordingsGroupedById,
-              referringHistoryRecordingsGroupedById,
-              bigShuffledHistoryOverLotsOfThings,
-              asOfs,
-              queryWhen
-            ) =>
-          Using.resource(makeWorld()) { world =>
-            recordEventsInWorld(
-              bigShuffledHistoryOverLotsOfThings,
-              asOfs,
-              world
-            )
-
-            val scope = world.scopeFor(queryWhen, world.nextRevision)
-
-            val checks =
-              for {
-                RecordingsNoLaterThan(
-                  _,
-                  referringHistoriesFrom,
-                  _,
-                  _,
-                  _
-                ) <- referringHistoryRecordingsGroupedById.flatMap(
-                  _.thePartNoLaterThan(queryWhen)
-                )
-                NonExistentRecordings(
-                  referencedHistoryId,
-                  referencedHistoriesFrom,
-                  _
-                ) <- referencedHistoryRecordingsGroupedById.flatMap(
-                  _.doesNotExistAt(queryWhen)
-                )
-                Seq(referringHistory: ReferringHistory) =
-                  referringHistoriesFrom(scope)
-                if referringHistory.referencedHistories
-                  .get(referencedHistoryId)
-                  .exists(!_.asInstanceOf[ItemExtensionApi].isGhost)
-                Seq(referencedHistory) = referencedHistoriesFrom(scope)
-              } yield (referencedHistoryId, referencedHistory)
-
-            if (checks.isEmpty) Trials.reject()
-
-            for ((referencedHistoryId, referencedHistory) <- checks) {
-              withClue(
-                s"Referenced history id: $referencedHistoryId should be defined by the reference."
-              )(assert(referencedHistory.datums.isEmpty))
-            }
-          }
-      }
-  }
-
-  @TestFactory
+@TestFactory
   def yieldTheSameIdentityForARelatedItemAsWhenThatItemIsDirectlyQueriedFor(): DynamicTests = {
     val testCaseTrials = for {
       referencedHistoryRecordingsGroupedById <-
@@ -1376,7 +1057,7 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
       }
   }
 
-  @TestFactory
+@TestFactory
   def notRevealAnItemAtAQueryTimeComingBeforeItsFirstDefiningEvent(): DynamicTests = {
     val testCaseTrials = for {
       recordingsGroupedById <- recordingsGroupedByIdTrials(
@@ -1440,7 +1121,7 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
     }
   }
 
-  @TestFactory
+@TestFactory
   def notConsiderAnIneffectiveEventAsBeingDefining(): DynamicTests = {
     val testCaseTrials = for {
       recordingsGroupedById <- recordingsGroupedByIdTrials(
@@ -1529,7 +1210,95 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
     }
   }
 
-  @TestFactory
+@TestFactory
+  def considerAReferenceToARelatedItemInAnEventAsBeingDefining(): DynamicTests = {
+    val testCaseTrials = for {
+      referencedHistoryRecordingsGroupedById <-
+        referencedHistoryRecordingsGroupedByIdTrials(
+          forbidAnnihilations = false
+        )
+      referringHistoryRecordingsGroupedById <-
+        referringHistoryRecordingsGroupedByIdTrials()
+      obsoleteRecordingsGroupedById <-
+        nonConflictingRecordingsGroupedByIdTrials
+      shuffledRecordings <- shuffleRecordingsPreservingRelativeOrderOfEventsAtTheSameWhen(
+        referencedHistoryRecordingsGroupedById ++ referringHistoryRecordingsGroupedById
+      )
+      shuffledObsoleteRecordings <- shuffleRecordingsPreservingRelativeOrderOfEventsAtTheSameWhen(
+        obsoleteRecordingsGroupedById
+      )
+      bigShuffledHistoryOverLotsOfThings <- intersperseObsoleteEventsAmericium(
+        shuffledRecordings,
+        shuffledObsoleteRecordings
+      )
+      asOfs <- instantTrials
+        .listsOfSize(bigShuffledHistoryOverLotsOfThings.size)
+        .map(_.sorted)
+      queryWhen <- unboundedInstantTrials
+    } yield RelatedItemTestCase(
+      referencedHistoryRecordingsGroupedById,
+      referringHistoryRecordingsGroupedById,
+      bigShuffledHistoryOverLotsOfThings,
+      asOfs,
+      queryWhen
+    )
+    testCaseTrials
+      .withStrategy(_ => CasesLimitStrategy.counted(200, 20))
+      .dynamicTests {
+        case RelatedItemTestCase(
+              referencedHistoryRecordingsGroupedById,
+              referringHistoryRecordingsGroupedById,
+              bigShuffledHistoryOverLotsOfThings,
+              asOfs,
+              queryWhen
+            ) =>
+          Using.resource(makeWorld()) { world =>
+            recordEventsInWorld(
+              bigShuffledHistoryOverLotsOfThings,
+              asOfs,
+              world
+            )
+
+            val scope = world.scopeFor(queryWhen, world.nextRevision)
+
+            val checks =
+              for {
+                RecordingsNoLaterThan(
+                  _,
+                  referringHistoriesFrom,
+                  _,
+                  _,
+                  _
+                ) <- referringHistoryRecordingsGroupedById.flatMap(
+                  _.thePartNoLaterThan(queryWhen)
+                )
+                NonExistentRecordings(
+                  referencedHistoryId,
+                  referencedHistoriesFrom,
+                  _
+                ) <- referencedHistoryRecordingsGroupedById.flatMap(
+                  _.doesNotExistAt(queryWhen)
+                )
+                Seq(referringHistory: ReferringHistory) =
+                  referringHistoriesFrom(scope)
+                if referringHistory.referencedHistories
+                  .get(referencedHistoryId)
+                  .exists(!_.asInstanceOf[ItemExtensionApi].isGhost)
+                Seq(referencedHistory) = referencedHistoriesFrom(scope)
+              } yield (referencedHistoryId, referencedHistory)
+
+            if (checks.isEmpty) Trials.reject()
+
+            for ((referencedHistoryId, referencedHistory) <- checks) {
+              withClue(
+                s"Referenced history id: $referencedHistoryId should be defined by the reference."
+              )(assert(referencedHistory.datums.isEmpty))
+            }
+          }
+      }
+  }
+
+@TestFactory
   def treatAnAnnihilatedItemAccessedViaAReferenceToARelatedItemAsBeingAGhost(): DynamicTests = {
     val testCaseTrials = for {
       referencedHistoryRecordingsGroupedById <-
@@ -1658,7 +1427,7 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
     }
   }
 
-  @TestFactory
+@TestFactory
   def notAllowAnEventToEitherReferToOrToMutateTheStateOfARelatedItemThatIsAGhost(): DynamicTests = {
     val testCaseTrials = for {
       referencedHistoryRecordingsGroupedById <-
@@ -1805,7 +1574,7 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
     }
   }
 
-  @TestFactory
+@TestFactory
   def notPermitTheAnnihilationOfAnItemAtAQueryTimeComingBeforeItsFirstDefiningEvent(): DynamicTests = {
     val testCaseTrials = for {
       recordingsGroupedById <- integerHistoryRecordingsGroupedByIdTrials
@@ -1885,7 +1654,7 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
     }
   }
 
-  @TestFactory
+@TestFactory
   def haveANextRevisionThatReflectsTheLastAddedRevision(): DynamicTests = {
     val testCaseTrials = for {
       recordingsGroupedById <- recordingsGroupedByIdTrials(
@@ -1929,7 +1698,7 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
     }
   }
 
-  @TestFactory
+@TestFactory
   def haveAVersionTimelineThatRecordsTheAsOfTimeForEachOfItsRevisions(): DynamicTests = {
     val testCaseTrials = for {
       recordingsGroupedById <- recordingsGroupedByIdTrials(
@@ -1973,7 +1742,7 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
     }
   }
 
-  @TestFactory
+@TestFactory
   def haveASortedVersionTimeline(): DynamicTests = {
     val testCaseTrials = for {
       recordingsGroupedById <- recordingsGroupedByIdTrials(
@@ -2019,7 +1788,7 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
     }
   }
 
-  @TestFactory
+@TestFactory
   def allocateRevisionNumbersSequentially(): DynamicTests = {
     val testCaseTrials = for {
       recordingsGroupedById <- recordingsGroupedByIdTrials(
@@ -2065,7 +1834,7 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
     }
   }
 
-  @TestFactory
+@TestFactory
   def haveANextRevisionNumberThatIsTheSizeOfItsVersionTimeline(): DynamicTests = {
     val testCaseTrials = for {
       recordingsGroupedById <- recordingsGroupedByIdTrials(
@@ -2109,7 +1878,74 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
     }
   }
 
-  @TestFactory
+@TestFactory
+  def notPermitTheAsOfTimeForANewRevisionToBeLessThanThatOfAnyExistingRevision(): DynamicTests = {
+    val testCaseTrials = for {
+      recordingsGroupedById <- recordingsGroupedByIdTrials(
+        forbidAnnihilations = false
+      )
+      obsoleteRecordingsGroupedById <-
+        nonConflictingRecordingsGroupedByIdTrials
+      shuffledRecordings <-
+        shuffleRecordingsPreservingRelativeOrderOfEventsAtTheSameWhen(
+          recordingsGroupedById
+        )
+      shuffledObsoleteRecordings <-
+        shuffleRecordingsPreservingRelativeOrderOfEventsAtTheSameWhen(
+          obsoleteRecordingsGroupedById
+        )
+      bigShuffledHistoryOverLotsOfThings <- intersperseObsoleteEventsAmericium(
+        shuffledRecordings,
+        shuffledObsoleteRecordings
+      )
+      asOfs <- instantTrials
+        .listsOfSize(bigShuffledHistoryOverLotsOfThings.size)
+        .map(_.sorted)
+      if 1 < asOfs.toSet.size
+      candidateIndicesToStartATranspose =
+        asOfs.zip(asOfs.tail).zipWithIndex filter {
+          case ((first, second), index) => first isBefore second
+        } map (_._2)
+      indexOfFirstAsOfBeingTransposed <- api.choose(candidateIndicesToStartATranspose)
+    } yield (
+      bigShuffledHistoryOverLotsOfThings,
+      asOfs,
+      indexOfFirstAsOfBeingTransposed
+    )
+
+    testCaseTrials.withLimit(200).dynamicTests {
+      case (
+            bigShuffledHistoryOverLotsOfThings,
+            asOfs,
+            indexOfFirstAsOfBeingTransposed
+          ) =>
+        Using.resource(makeWorld()) { world =>
+          val asOfsWithIncorrectTransposition =
+            asOfs.splitAt(indexOfFirstAsOfBeingTransposed) match {
+              case (
+                    asOfsBeforeTransposition,
+                    Seq(first, second, asOfsAfterTransposition @ _*)
+                  ) =>
+                asOfsBeforeTransposition ++ Seq(
+                  second,
+                  first
+                ) ++ asOfsAfterTransposition
+            }
+
+          assertThrows(
+            classOf[IllegalArgumentException],
+            () =>
+              recordEventsInWorld(
+                bigShuffledHistoryOverLotsOfThings,
+                asOfsWithIncorrectTransposition,
+                world
+              )
+          )
+        }
+    }
+  }
+
+@TestFactory
   def createAScopeWhosePropertiesRelateToTheCallToScopeForWhenUsingTheNextRevisionOverload(): DynamicTests = {
     val testCaseTrials = for {
       recordingsGroupedById <- recordingsGroupedByIdTrials(
@@ -2208,7 +2044,7 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
     }
   }
 
-  @TestFactory
+@TestFactory
   def createAScopeWhosePropertiesRelateToTheCallToScopeForWhenUsingTheAsOfTimeOverload(): DynamicTests = {
     val testCaseTrials = for {
       recordingsGroupedById <- recordingsGroupedByIdTrials(
@@ -2300,7 +2136,7 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
     }
   }
 
-  @TestFactory
+@TestFactory
   def createAScopeThatIsASnapshotUnaffectedBySubsequentRevisions(): DynamicTests = {
     val testCaseTrials = for {
       recordingsGroupedById <- recordingsGroupedByIdTrials(
@@ -2384,7 +2220,7 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
     }
   }
 
-  @TestFactory
+@TestFactory
   def createRevisionsWithTheStrongExceptionSafetyGuarantee(): DynamicTests = {
     val testCaseTrials = for {
       recordingsGroupedById <- nonConflictingRecordingsGroupedByIdTrials
@@ -2485,7 +2321,7 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
     }
   }
 
-  @TestFactory
+@TestFactory
   def yieldTheSameHistoriesForScopesIncludingAllChangesAtTheLatestRevisionRegardlessOfHowChangesAreGroupedIntoRevisions()
       : DynamicTests = {
     val testCaseTrials = for {
@@ -2572,72 +2408,321 @@ trait WorldBehaviourAmericium extends WorldSpecSupportAmericium {
     }
   }
 
-  @TestFactory
-  def notPermitTheAsOfTimeForANewRevisionToBeLessThanThatOfAnyExistingRevision(): DynamicTests = {
+@TestFactory
+  def extendTheHistoryOfAnItemWhoseAnnihilationIsAnnulledToPickUpAnySubsequentEventsRelatingToThatItem()
+      : DynamicTests = {
+    val itemId = "Fred"
+
     val testCaseTrials = for {
-      recordingsGroupedById <- recordingsGroupedByIdTrials(
-        forbidAnnihilations = false
+      eventTimes <- instantTrials.nonEmptyLists.map(_.sorted)
+      annihilationWhen <- instantTrials.filter(when =>
+        when.isAfter(eventTimes.head) && !when.isAfter(eventTimes.last)
       )
-      obsoleteRecordingsGroupedById <-
-        nonConflictingRecordingsGroupedByIdTrials
+      steps = 1 to eventTimes.size
+      recordings: List[(Unbounded[Instant], Event)] =
+        eventTimes.zip(steps).map { case (when, step) =>
+          Finite(when) -> Change
+            .forOneItem[IntegerHistory](when)(
+              itemId,
+              { item: IntegerHistory =>
+                item.integerProperty = step
+              }
+            )
+        }
       shuffledRecordings <-
-        shuffleRecordingsPreservingRelativeOrderOfEventsAtTheSameWhen(
-          recordingsGroupedById
+        shuffleRecordingsPreservingRelativeOrderOfEventsAtTheSameWhenForAGivenItem(
+          recordings
         )
-      shuffledObsoleteRecordings <-
-        shuffleRecordingsPreservingRelativeOrderOfEventsAtTheSameWhen(
-          obsoleteRecordingsGroupedById
-        )
-      bigShuffledHistoryOverLotsOfThings <- intersperseObsoleteEventsAmericium(
-        shuffledRecordings,
-        shuffledObsoleteRecordings
-      )
+      bigShuffledHistoryOverLotsOfThings <- api
+        .splitsIntoNonEmptyPieces(shuffledRecordings.zipWithIndex)
       asOfs <- instantTrials
         .listsOfSize(bigShuffledHistoryOverLotsOfThings.size)
         .map(_.sorted)
-      if 1 < asOfs.toSet.size
-      candidateIndicesToStartATranspose =
-        asOfs.zip(asOfs.tail).zipWithIndex filter {
-          case ((first, second), index) => first isBefore second
-        } map (_._2)
-      indexOfFirstAsOfBeingTransposed <- api.choose(candidateIndicesToStartATranspose)
-    } yield (
-      bigShuffledHistoryOverLotsOfThings,
+    } yield AnnulledAnnihilationTestCase(
+      liftRecordings(bigShuffledHistoryOverLotsOfThings),
       asOfs,
-      indexOfFirstAsOfBeingTransposed
+      steps,
+      annihilationWhen
     )
 
     testCaseTrials.withLimit(200).dynamicTests {
-      case (
+      case AnnulledAnnihilationTestCase(
             bigShuffledHistoryOverLotsOfThings,
             asOfs,
-            indexOfFirstAsOfBeingTransposed
+            steps,
+            annihilationWhen
           ) =>
         Using.resource(makeWorld()) { world =>
-          val asOfsWithIncorrectTransposition =
-            asOfs.splitAt(indexOfFirstAsOfBeingTransposed) match {
-              case (
-                    asOfsBeforeTransposition,
-                    Seq(first, second, asOfsAfterTransposition @ _*)
-                  ) =>
-                asOfsBeforeTransposition ++ Seq(
-                  second,
-                  first
-                ) ++ asOfsAfterTransposition
-            }
+          val initialEventId = -2
 
-          assertThrows(
-            classOf[IllegalArgumentException],
-            () =>
-              recordEventsInWorld(
-                bigShuffledHistoryOverLotsOfThings,
-                asOfsWithIncorrectTransposition,
-                world
-              )
+          world.revise(
+            initialEventId,
+            Change.forOneItem[IntegerHistory](annihilationWhen)(
+              itemId,
+              { item: IntegerHistory =>
+                item.integerProperty = -1
+              }
+            ),
+            asOfs.head
           )
+
+          val annihilationEventId = -1
+
+          world.revise(
+            annihilationEventId,
+            Annihilation[Any](annihilationWhen, itemId),
+            asOfs.head
+          )
+
+          recordEventsInWorld(
+            bigShuffledHistoryOverLotsOfThings,
+            asOfs,
+            world
+          )
+
+          world.annul(initialEventId, asOfs.last)
+
+          world.annul(annihilationEventId, asOfs.last)
+
+          val scope =
+            world
+              .scopeFor(PositiveInfinity, world.nextRevision)
+
+          val fredTheItem = scope
+            .render(Bitemporal.withId[IntegerHistory](itemId))
+            .toList
+
+          assert(steps == fredTheItem.head.datums)
         }
     }
   }
+
+@TestFactory
+  def buildAnItemStateInAMannerConsistentWithTheHistoryExperiencedByTheItemRegardlessOfAnyCorrectedHistory()
+      : DynamicTests = {
+    val itemId = "Fred"
+
+    val testCaseTrials = for {
+      eventTimes <- instantTrials.nonEmptyLists.map(_.sorted)
+      steps = 1 to eventTimes.size
+      recordings: List[(Unbounded[Instant], Event)] =
+        eventTimes.zip(steps).map { case (when, step) =>
+          Finite(when) -> Change
+            .forOneItem[IntegerHistory](when)(
+              itemId,
+              { item: IntegerHistory =>
+                item.integerProperty = step
+              }
+            )
+        }
+      obsoleteEventTimes <- instantTrials.nonEmptyLists
+      obsoleteSteps = 1 to obsoleteEventTimes.size
+      obsoleteRecordings: List[(Unbounded[Instant], Event)] =
+        obsoleteEventTimes.zip(obsoleteSteps).map { case (when, step) =>
+          Finite(when) -> Change
+            .forOneItem[IntegerHistory](when)(
+              itemId,
+              { item: IntegerHistory =>
+                item.integerProperty = step
+              }
+            )
+        }
+      shuffledRecordings <-
+        shuffleRecordingsPreservingRelativeOrderOfEventsAtTheSameWhenForAGivenItem(
+          recordings
+        )
+      shuffledObsoleteRecordings <-
+        shuffleRecordingsPreservingRelativeOrderOfEventsAtTheSameWhenForAGivenItem(
+          obsoleteRecordings
+        )
+      bigShuffledHistoryOverLotsOfThings <-
+        intersperseObsoleteEventsAmericium(
+          shuffledRecordings,
+          shuffledObsoleteRecordings
+        )
+      asOfs <- instantTrials
+        .listsOfSize(bigShuffledHistoryOverLotsOfThings.size)
+        .map(_.sorted)
+    } yield StateConsistencyTestCase(
+      bigShuffledHistoryOverLotsOfThings,
+      asOfs,
+      steps
+    )
+
+    testCaseTrials.withLimit(200).dynamicTests {
+      case StateConsistencyTestCase(
+            bigShuffledHistoryOverLotsOfThings,
+            asOfs,
+            steps
+          ) =>
+        Using.resource(makeWorld()) { world =>
+          recordEventsInWorld(
+            bigShuffledHistoryOverLotsOfThings,
+            asOfs,
+            world
+          )
+
+          val scope =
+            world
+              .scopeFor(PositiveInfinity, world.nextRevision)
+
+          val fredTheItem = scope
+            .render(Bitemporal.withId[IntegerHistory](itemId))
+            .toList
+
+          assert(steps == fredTheItem.head.datums)
+        }
+    }
+  }
+
+@TestFactory
+  def buildAnItemStateInAMannerConsistentWithTheHistoryExperiencedByTheItemRegardlessOfAnyCorrectedHistoryWithATwist()
+      : DynamicTests = {
+    val itemId = "Fred"
+
+    val testCaseTrials = for {
+      eventTimes <- instantTrials.nonEmptyLists.map(_.sorted)
+      steps = 1 to eventTimes.size
+      recordings: List[(Unbounded[Instant], Event)] =
+        eventTimes.zip(steps).map { case (when, step) =>
+          Finite(when) -> Change
+            .forOneItem[IntegerHistory](when)(
+              itemId,
+              { item: IntegerHistory =>
+                item.integerProperty = step
+              }
+            )
+        }
+      shuffledRecordings <-
+        shuffleRecordingsPreservingRelativeOrderOfEventsAtTheSameWhenForAGivenItem(
+          recordings
+        )
+      shuffledObsoleteRecordings <-
+        shuffleRecordingsPreservingRelativeOrderOfEventsAtTheSameWhenForAGivenItem(
+          recordings
+        )
+      bigShuffledHistoryOverLotsOfThings <-
+        intersperseObsoleteEventsAmericium(
+          shuffledRecordings,
+          shuffledObsoleteRecordings
+        )
+      asOfs <- instantTrials
+        .listsOfSize(bigShuffledHistoryOverLotsOfThings.size)
+        .map(_.sorted)
+    } yield StateConsistencyTestCase(
+      bigShuffledHistoryOverLotsOfThings,
+      asOfs,
+      steps
+    )
+
+    testCaseTrials.withLimit(200).dynamicTests {
+      case StateConsistencyTestCase(
+            bigShuffledHistoryOverLotsOfThings,
+            asOfs,
+            steps
+          ) =>
+        Using.resource(makeWorld()) { world =>
+          recordEventsInWorld(
+            bigShuffledHistoryOverLotsOfThings,
+            asOfs,
+            world
+          )
+
+          val scope =
+            world
+              .scopeFor(PositiveInfinity, world.nextRevision)
+
+          val fredTheItem = scope
+            .render(Bitemporal.withId[IntegerHistory](itemId))
+            .toList
+
+          assert(steps == fredTheItem.head.datums)
+        }
+    }
+  }
+
+@TestFactory
+  def buildAnItemStateInAMannerConsistentWithTheHistoryExperiencedByTheItemRegardlessOfAnyCorrectedHistoryWithAnotherTwist()
+      : DynamicTests = {
+    val itemId = "Fred"
+
+    val testCaseTrials = for {
+      eventTimes <- api
+        .integers(0, 50)
+        .map(0 to _ toList)
+        .map(
+          _.map(timeInSeconds =>
+            Instant.ofEpochSecond(24 * 60 * 60 * timeInSeconds)
+          )
+        )
+      steps = 1 to eventTimes.size
+      recordings: List[(Unbounded[Instant], Event)] =
+        eventTimes.zip(steps).map { case (when, step) =>
+          Finite(when) -> Change
+            .forOneItem[IntegerHistory](when)(
+              itemId,
+              { item: IntegerHistory =>
+                item.integerProperty = step
+              }
+            )
+        }
+      shuffledObsoleteEventTimes <- api.shuffles(eventTimes)
+      obsoleteSteps = 1 to shuffledObsoleteEventTimes.size
+      obsoleteRecordings: List[(Unbounded[Instant], Event)] =
+        shuffledObsoleteEventTimes.zip(obsoleteSteps).map { case (when, step) =>
+          Finite(when) -> Change
+            .forOneItem[IntegerHistory](when)(
+              itemId,
+              { item: IntegerHistory =>
+                item.integerProperty = step
+              }
+            )
+        }
+
+      pairsOfObsoleteAndSucceedingEvents =
+        obsoleteRecordings.zipWithIndex.zip(recordings.zipWithIndex)
+
+      historyOverLotsOfThings = pairsOfObsoleteAndSucceedingEvents
+        .flatMap { case (obsolete, succeeding) =>
+          Seq(Seq(obsolete), Seq(succeeding))
+        }
+
+      asOfs <- instantTrials
+        .listsOfSize(historyOverLotsOfThings.length)
+        .map(_.sorted)
+    } yield StateConsistencyTestCase(
+      liftRecordings(historyOverLotsOfThings),
+      asOfs,
+      steps
+    )
+
+    testCaseTrials.withLimit(200).dynamicTests {
+      case StateConsistencyTestCase(
+            historyOverLotsOfThings,
+            asOfs,
+            steps
+          ) =>
+        Using.resource(makeWorld()) { world =>
+          recordEventsInWorld(
+            historyOverLotsOfThings,
+            asOfs,
+            world
+          )
+
+          val scope =
+            world
+              .scopeFor(PositiveInfinity, world.nextRevision)
+
+          val fredTheItem = scope
+            .render(Bitemporal.withId[IntegerHistory](itemId))
+            .toList
+
+          assert(steps.toSet == fredTheItem.head.datums.toSet)
+        }
+    }
+  }
+
+
 
   abstract class NonExistentHistory extends History {
     override type Id = NonExistentId

--- a/src/test/scala/com/sageserpent/plutonium/WorldSpecSupportAmericium.scala
+++ b/src/test/scala/com/sageserpent/plutonium/WorldSpecSupportAmericium.scala
@@ -70,6 +70,21 @@ trait WorldSpecSupportAmericium {
       nonConflictingDataSamplesForAnIdTrials,
       forbidAnnihilations = true
     )
+
+  def variablyTypedDataSamplesForAnIdTrials =
+    dataSamplesForAnIdTrials[FooHistory](
+      fooHistoryIdTrials.map("Foo_" + _),
+      api.alternate(
+        moreSpecificFooHistoryDataSampleTrials(faulty = false),
+        fooHistoryDataSampleTrials1(faulty = false)
+      )
+    )
+
+  def variablyTypedRecordingsGroupedByIdTrials =
+    recordingsGroupedByIdTrials_(
+      variablyTypedDataSamplesForAnIdTrials,
+      forbidAnnihilations = true
+    )
   def integerDataSamplesForAnIdTrials =
     dataSamplesForAnIdTrials[IntegerHistory](
       integerHistoryIdTrials,


### PR DESCRIPTION
I have reordered the existing ported tests in WorldBehaviourAmericium.scala to match the order in WorldBehaviours.scala and ported one additional test: 'reveal the same history from a scope with an asOf limit that comes at or after that revision but before the following revision'.

---
*PR created automatically by Jules for task [11222079111511624744](https://jules.google.com/task/11222079111511624744) started by @sageserpent-open*